### PR TITLE
Cache to disk

### DIFF
--- a/core/src/main/scala/spark/BoundedMemoryCache.scala
+++ b/core/src/main/scala/spark/BoundedMemoryCache.scala
@@ -60,10 +60,14 @@ class BoundedMemoryCache extends Cache with Logging {
     val iter = map.entrySet.iterator
     while (maxBytes - currentBytes < space && iter.hasNext) {
       val mapEntry = iter.next()
-      logInfo("Dropping key %s of size %d to make space".format(
-        mapEntry.getKey, mapEntry.getValue.size))
+      dropEntry(mapEntry.getKey, mapEntry.getValue)
       currentBytes -= mapEntry.getValue.size
       iter.remove()
     }
+  }
+
+  protected def dropEntry(key: Any, entry: Entry) {
+    logInfo("Dropping key %s of size %d to make space".format(
+      key, entry.size))
   }
 }

--- a/core/src/main/scala/spark/DiskSpillingCache.scala
+++ b/core/src/main/scala/spark/DiskSpillingCache.scala
@@ -27,6 +27,7 @@ class DiskSpillingCache extends BoundedMemoryCache {
             val timeTaken = System.currentTimeMillis - startTime
             logInfo("Reading key %s of size %d bytes from disk took %d ms".format(
               key, file.length, timeTaken))
+            super.put(key, bytes)
             ser.deserialize(bytes.asInstanceOf[Array[Byte]])
 
           case _ => // not found
@@ -42,9 +43,8 @@ class DiskSpillingCache extends BoundedMemoryCache {
   }
 
   /**
-   * Spill least recently used entries to disk until at least space
-   * bytes are free. Assumes that a lock is held on the DiskSpillingCache.
-   * Assumes that entry.value is a byte array.
+   * Spill the given entry to disk. Assumes that a lock is held on the
+   * DiskSpillingCache.  Assumes that entry.value is a byte array.
    */
   override protected def dropEntry(key: Any, entry: Entry) {
     logInfo("Spilling key %s of size %d to make space".format(

--- a/core/src/main/scala/spark/DiskSpillingCache.scala
+++ b/core/src/main/scala/spark/DiskSpillingCache.scala
@@ -1,0 +1,61 @@
+package spark
+
+import java.io.File
+import java.io.{FileOutputStream,FileInputStream}
+import java.util.LinkedHashMap
+import java.util.UUID
+
+// TODO: error handling
+// TODO: cache into a separate directory using Utils.createTempDir
+// TODO: after reading an entry from disk, put it into the cache
+
+class DiskSpillingCache extends BoundedMemoryCache {
+  private val diskMap = new LinkedHashMap[Any, File](32, 0.75f, true)
+
+  override def get(key: Any): Any = {
+    synchronized {
+      val ser = Serializer.newInstance()
+      super.get(key) match {
+        case bytes: Any => // found in memory
+          ser.deserialize(bytes.asInstanceOf[Array[Byte]])
+
+        case _ => diskMap.get(key) match {
+          case file: Any => // found on disk
+            val startTime = System.currentTimeMillis
+            val bytes = new Array[Byte](file.length.toInt)
+            new FileInputStream(file).read(bytes)
+            val timeTaken = System.currentTimeMillis - startTime
+            logInfo("Reading key %s of size %d bytes from disk took %d ms".format(
+              key, file.length, timeTaken))
+            ser.deserialize(bytes.asInstanceOf[Array[Byte]])
+
+          case _ => // not found
+            null
+        }
+      }
+    }
+  }
+
+  override def put(key: Any, value: Any) {
+    var ser = Serializer.newInstance()
+    super.put(key, ser.serialize(value))
+  }
+
+  /**
+   * Spill least recently used entries to disk until at least space
+   * bytes are free. Assumes that a lock is held on the DiskSpillingCache.
+   * Assumes that entry.value is a byte array.
+   */
+  override protected def dropEntry(key: Any, entry: Entry) {
+    logInfo("Spilling key %s of size %d to make space".format(
+      key, entry.size))
+    val cacheDir = System.getProperty(
+      "spark.DiskSpillingCache.cacheDir",
+      System.getProperty("java.io.tmpdir"))
+    val file = new File(cacheDir, "spark-dsc-" + UUID.randomUUID.toString)
+    val stream = new FileOutputStream(file)
+    stream.write(entry.value.asInstanceOf[Array[Byte]])
+    stream.close()
+    diskMap.put(key, file)
+  }
+}


### PR DESCRIPTION
DiskSpillingCache is a cache implementation derived from BoundedMemoryCache that spills entries to disk when it runs out of space.

The location on disk where entries are stored is configurable through the spark.diskSpillingCache.cacheDir property.
