### PR TITLE
Fix deprecations when compiled with Scala 2.8.1

### DIFF
--- a/core/src/main/scala/spark/BitTorrentBroadcast.scala
+++ b/core/src/main/scala/spark/BitTorrentBroadcast.scala
@@ -203,7 +203,7 @@ extends Broadcast[T] with Logging {
     var blockID = 0
 
     for (i <- 0 until (byteArray.length, blockSize)) {
-      val thisBlockSize = Math.min (blockSize, byteArray.length - i)
+      val thisBlockSize = math.min (blockSize, byteArray.length - i)
       var tempByteArray = new Array[Byte] (thisBlockSize)
       val hasRead = bais.read (tempByteArray, 0, thisBlockSize)
       
@@ -435,7 +435,7 @@ extends Broadcast[T] with Logging {
       
       while (hasBlocks < totalBlocks) {
         var numThreadsToCreate = 
-          Math.min (listOfSources.size, BitTorrentBroadcast.MaxTxPeers) - 
+          math.min (listOfSources.size, BitTorrentBroadcast.MaxTxPeers) -
           threadPool.getActiveCount
 
         while (hasBlocks < totalBlocks && numThreadsToCreate > 0) {

--- a/core/src/main/scala/spark/BitTorrentBroadcast.scala
+++ b/core/src/main/scala/spark/BitTorrentBroadcast.scala
@@ -113,7 +113,7 @@ extends Broadcast[T] with Logging {
     }
     
     // In the beginning, this is the only known source to Guide
-    listOfSources = listOfSources + masterSource
+    listOfSources += masterSource
 
     // Register with the Tracker
     BitTorrentBroadcast.registerValue (uuid, 
@@ -268,7 +268,7 @@ extends Broadcast[T] with Logging {
       if (listOfSources.contains(newSourceInfo)) { 
         listOfSources = listOfSources - newSourceInfo 
       }
-      listOfSources = listOfSources + newSourceInfo
+      listOfSources += newSourceInfo
     }         
   }  
   
@@ -446,7 +446,7 @@ extends Broadcast[T] with Logging {
             // Add to peersNowTalking. Remove in the thread. We have to do this 
             // ASAP, otherwise pickPeerToTalkTo picks the same peer more than once
             peersNowTalking.synchronized { 
-              peersNowTalking = peersNowTalking + peerToTalkTo
+              peersNowTalking += peerToTalkTo
             }
           }
           
@@ -878,7 +878,7 @@ extends Broadcast[T] with Logging {
                 i = i - 1
               }
               
-              selectedSources = selectedSources + curPeer
+              selectedSources += curPeer
               alreadyPicked.set (i)
               
               picksLeft = picksLeft - 1

--- a/core/src/main/scala/spark/CacheTracker.scala
+++ b/core/src/main/scala/spark/CacheTracker.scala
@@ -38,7 +38,7 @@ class CacheTrackerActor extends DaemonActor with Logging {
           
         case DroppedFromCache(rddId, partition, host) =>
           logInfo("Cache entry removed: (%s, %s) on %s".format(rddId, partition, host))
-          locs(rddId)(partition) -= host
+          locs(rddId)(partition) = locs(rddId)(partition).filterNot(_ == host)
         
         case MemoryCacheLost(host) =>
           logInfo("Memory cache lost on " + host)

--- a/core/src/main/scala/spark/CacheTracker.scala
+++ b/core/src/main/scala/spark/CacheTracker.scala
@@ -111,7 +111,7 @@ class CacheTracker(isMaster: Boolean, theCache: Cache) extends Logging {
     if (cachedVal != null) {
       // Split is in cache, so just return its values
       logInfo("Found partition in cache!")
-      return Iterator.fromArray(cachedVal.asInstanceOf[Array[T]])
+      return cachedVal.asInstanceOf[Array[T]].iterator
     } else {
       // Mark the split as loading (unless someone else marks it first)
       loading.synchronized {
@@ -119,7 +119,7 @@ class CacheTracker(isMaster: Boolean, theCache: Cache) extends Logging {
           while (loading.contains(key)) {
             try {loading.wait()} catch {case _ =>}
           }
-          return Iterator.fromArray(cache.get(key).asInstanceOf[Array[T]])
+          return cache.get(key).asInstanceOf[Array[T]].iterator
         } else {
           loading.add(key)
         }
@@ -138,7 +138,7 @@ class CacheTracker(isMaster: Boolean, theCache: Cache) extends Logging {
         loading.notifyAll()
       }
       future.apply() // Wait for the reply from the cache tracker
-      return Iterator.fromArray(array)
+      return array.iterator
     }
   }
 

--- a/core/src/main/scala/spark/ChainedBroadcast.scala
+++ b/core/src/main/scala/spark/ChainedBroadcast.scala
@@ -166,7 +166,7 @@ extends Broadcast[T] with Logging {
     var blockID = 0
 
     for (i <- 0 until (byteArray.length, blockSize)) {    
-      val thisBlockSize = Math.min (blockSize, byteArray.length - i)
+      val thisBlockSize = math.min (blockSize, byteArray.length - i)
       var tempByteArray = new Array[Byte] (thisBlockSize)
       val hasRead = bais.read (tempByteArray, 0, thisBlockSize)
       

--- a/core/src/main/scala/spark/CoGroupedRDD.scala
+++ b/core/src/main/scala/spark/CoGroupedRDD.scala
@@ -26,7 +26,7 @@ class CoGroupAggregator extends Aggregator[Any, Any, ArrayBuffer[Any]] (
 )
 
 class CoGroupedRDD[K](rdds: Seq[RDD[(_, _)]], part: Partitioner)
-extends RDD[(K, Seq[Seq[_]])](rdds.first.context) with Logging {
+extends RDD[(K, Seq[Seq[_]])](rdds.head.context) with Logging {
   val aggr = new CoGroupAggregator
   
   override val dependencies = {
@@ -45,7 +45,7 @@ extends RDD[(K, Seq[Seq[_]])](rdds.first.context) with Logging {
   }
   
   @transient val splits_ : Array[Split] = {
-    val firstRdd = rdds.first
+    val firstRdd = rdds.head
     val array = new Array[Split](part.numPartitions)
     for (i <- 0 until array.size) {
       array(i) = new CoGroupSplit(i, rdds.zipWithIndex.map { case (r, j) =>

--- a/core/src/main/scala/spark/DAGScheduler.scala
+++ b/core/src/main/scala/spark/DAGScheduler.scala
@@ -237,7 +237,7 @@ private trait DAGScheduler extends Scheduler with Logging {
                 if (stage.shuffleDep != None) {
                   mapOutputTracker.registerMapOutputs(
                     stage.shuffleDep.get.shuffleId,
-                    stage.outputLocs.map(_.first).toArray)
+                    stage.outputLocs.map(_.head).toArray)
                 }
                 updateCacheLocs()
                 val newlyRunnable = new ArrayBuffer[Stage]

--- a/core/src/main/scala/spark/RDD.scala
+++ b/core/src/main/scala/spark/RDD.scala
@@ -178,7 +178,7 @@ class SplitRDD[T: ClassManifest](prev: RDD[T])
 extends RDD[Array[T]](prev.context) {
   override def splits = prev.splits
   override val dependencies = List(new OneToOneDependency(prev))
-  override def compute(split: Split) = Iterator.fromArray(Array(prev.iterator(split).toArray))
+  override def compute(split: Split) = Array(prev.iterator(split).toArray).iterator
 }
 
 

--- a/core/src/main/scala/spark/Stage.scala
+++ b/core/src/main/scala/spark/Stage.scala
@@ -22,7 +22,7 @@ class Stage(val id: Int, val rdd: RDD[_], val shuffleDep: Option[ShuffleDependen
 
   def removeOutputLoc(partition: Int, host: String) {
     val prevList = outputLocs(partition)
-    val newList = prevList - host
+    val newList = prevList.filterNot(_ == host)
     outputLocs(partition) = newList
     if (prevList != Nil && newList == Nil)
       numAvailableOutputs -= 1

--- a/core/src/main/scala/spark/repl/SparkCompletion.scala
+++ b/core/src/main/scala/spark/repl/SparkCompletion.scala
@@ -107,7 +107,7 @@ class SparkCompletion(val repl: SparkInterpreter) extends SparkCompletionOutput 
   class TypeMemberCompletion(val tp: Type) extends CompletionAware with CompilerCompletion {
     def excludeEndsWith: List[String] = Nil
     def excludeStartsWith: List[String] = List("<") // <byname>, <repeated>, etc.
-    def excludeNames: List[String] = anyref.methodNames -- anyRefMethodsToShow ++ List("_root_")
+    def excludeNames: List[String] = anyref.methodNames.filterNot(anyRefMethodsToShow.contains) ++ List("_root_")
     
     def methodSignatureString(sym: Symbol) = {
       def asString = new MethodSymbolOutput(sym).methodString()

--- a/examples/src/main/scala/spark/examples/LocalALS.scala
+++ b/examples/src/main/scala/spark/examples/LocalALS.scala
@@ -106,8 +106,8 @@ object LocalALS {
     val R = generateR()
 
     // Initialize m and u randomly
-    var ms = Array.fromFunction(_ => factory1D.random(F))(M)
-    var us = Array.fromFunction(_ => factory1D.random(F))(U)
+    var ms = Array.fill(M)(factory1D.random(F))
+    var us = Array.fill(U)(factory1D.random(F))
 
     // Iteratively update movies then users
     for (iter <- 1 to ITERATIONS) {

--- a/examples/src/main/scala/spark/examples/LocalFileLR.scala
+++ b/examples/src/main/scala/spark/examples/LocalFileLR.scala
@@ -27,7 +27,7 @@ object LocalFileLR {
       println("On iteration " + i)
       var gradient = Vector.zeros(D)
       for (p <- points) {
-        val scale = (1 / (1 + Math.exp(-p.y * (w dot p.x))) - 1) * p.y
+        val scale = (1 / (1 + math.exp(-p.y * (w dot p.x))) - 1) * p.y
         gradient +=  scale * p.x
       }
       w -= gradient

--- a/examples/src/main/scala/spark/examples/LocalLR.scala
+++ b/examples/src/main/scala/spark/examples/LocalLR.scala
@@ -32,7 +32,7 @@ object LocalLR {
       println("On iteration " + i)
       var gradient = Vector.zeros(D)
       for (p <- data) {
-        val scale = (1 / (1 + Math.exp(-p.y * (w dot p.x))) - 1) * p.y
+        val scale = (1 / (1 + math.exp(-p.y * (w dot p.x))) - 1) * p.y
         gradient +=  scale * p.x
       }
       w -= gradient

--- a/examples/src/main/scala/spark/examples/LocalLR.scala
+++ b/examples/src/main/scala/spark/examples/LocalLR.scala
@@ -18,7 +18,7 @@ object LocalLR {
       val x = Vector(D, _ => rand.nextGaussian + y * R)
       DataPoint(x, y)
     }
-    Array.fromFunction(generatePoint _)(N)
+    Array.tabulate(N)(generatePoint)
   }
 
   def main(args: Array[String]) {

--- a/examples/src/main/scala/spark/examples/SparkALS.scala
+++ b/examples/src/main/scala/spark/examples/SparkALS.scala
@@ -117,8 +117,8 @@ object SparkALS {
     val R = generateR()
 
     // Initialize m and u randomly
-    var ms = Array.fromFunction(_ => factory1D.random(F))(M)
-    var us = Array.fromFunction(_ => factory1D.random(F))(U)
+    var ms = Array.fill(M)(factory1D.random(F))
+    var us = Array.fill(U)(factory1D.random(F))
 
     // Iteratively update movies then users
     val Rc  = spark.broadcast(R)

--- a/examples/src/main/scala/spark/examples/SparkLR.scala
+++ b/examples/src/main/scala/spark/examples/SparkLR.scala
@@ -20,7 +20,7 @@ object SparkLR {
       val x = Vector(D, _ => rand.nextGaussian + y * R)
       DataPoint(x, y)
     }
-    Array.fromFunction(generatePoint _)(N)
+    Array.tabulate(N)(generatePoint)
   }
 
   def main(args: Array[String]) {

--- a/project/plugins/SparkProjectPlugins.scala
+++ b/project/plugins/SparkProjectPlugins.scala
@@ -4,7 +4,7 @@ class SparkProjectPlugins(info: ProjectInfo) extends PluginDefinition(info) {
   val eclipse = "de.element34" % "sbt-eclipsify" % "0.7.0"
 
   val sbtIdeaRepo = "sbt-idea-repo" at "http://mpeltonen.github.com/maven/"
-  val sbtIdea = "com.github.mpeltonen" % "sbt-idea-plugin" % "0.2.0"
+  val sbtIdea = "com.github.mpeltonen" % "sbt-idea-plugin" % "0.4.0"
 
   val codaRepo = "Coda Hale's Repository" at "http://repo.codahale.com/"
   val assemblySBT = "com.codahale" % "assembly-sbt" % "0.1.1"


### PR DESCRIPTION
See issue #50. The change for `--` and `-` are the only controversial ones in my opinion and there's no better alternative as far as I know (it's the suggested approach in the deprecated message).
