### PR TITLE
Move managedStyle to SparkProject

### DIFF
--- a/project/build/SparkProject.scala
+++ b/project/build/SparkProject.scala
@@ -51,6 +51,7 @@ class SparkProject(info: ProjectInfo) extends ParentProject(info) with IdeaProje
 
   class BagelProject(info: ProjectInfo) extends DefaultProject(info) with BaseProject with DepJar with XmlTestReport
 
+  override def managedStyle = ManagedStyle.Maven
 }
 
 
@@ -103,5 +104,4 @@ trait DepJar extends AssemblyBuilder {
       depJarOutputPath,
       packageOptions)
   }.dependsOn(compile).describedAs("Bundle project's dependencies into a JAR.")
-  override def managedStyle = ManagedStyle.Maven
 }


### PR DESCRIPTION
I had added it to DepJar by mistake. This is not urgent and it could be merged after the other work you have planned for the coming week. I just put it here as a heads-up.
