### PR TITLE
Implemented RDD.leftOuterJoin and RDD.rightOuterJoin

### DIFF
--- a/core/src/test/scala/spark/ShuffleSuite.scala
+++ b/core/src/test/scala/spark/ShuffleSuite.scala
@@ -115,6 +115,38 @@ class ShuffleSuite extends FunSuite {
     sc.stop()
   }
 
+  test("leftOuterJoin") {
+    val sc = new SparkContext("local", "test")
+    val rdd1 = sc.parallelize(Array((1, 1), (1, 2), (2, 1), (3, 1)))
+    val rdd2 = sc.parallelize(Array((1, 'x'), (2, 'y'), (2, 'z'), (4, 'w')))
+    val joined = rdd1.leftOuterJoin(rdd2).collect()
+    assert(joined.size === 5)
+    assert(joined.toSet === Set(
+      (1, (1, Some('x'))),
+      (1, (2, Some('x'))),
+      (2, (1, Some('y'))),
+      (2, (1, Some('z'))),
+      (3, (1, None))
+    ))
+    sc.stop()
+  }
+
+  test("rightOuterJoin") {
+    val sc = new SparkContext("local", "test")
+    val rdd1 = sc.parallelize(Array((1, 1), (1, 2), (2, 1), (3, 1)))
+    val rdd2 = sc.parallelize(Array((1, 'x'), (2, 'y'), (2, 'z'), (4, 'w')))
+    val joined = rdd1.rightOuterJoin(rdd2).collect()
+    assert(joined.size === 5)
+    assert(joined.toSet === Set(
+      (1, (Some(1), 'x')),
+      (1, (Some(2), 'x')),
+      (2, (Some(1), 'y')),
+      (2, (Some(1), 'z')),
+      (4, (None, 'w'))
+    ))
+    sc.stop()
+  }
+
   test("join with no matches") {
     val sc = new SparkContext("local", "test")
     val rdd1 = sc.parallelize(Array((1, 1), (1, 2), (2, 1), (3, 1)))


### PR DESCRIPTION
I decided to implement them from scratch on the `join` method model rather than filtering out the output of `groupWith` to avoid emitting intermediate results that are dropped right afterward.

I think it's better to use the scala Option type to handle missing values rather that null values as in SQL or Pig, tell be if you don't aggree.

_Note_: There is no scaladoc on those methods as they all lack such documentation in the RDD class. I really think this is missing though. Maybe the RDD should be fully documented at once in another pull request?
