### PR TITLE
Upgrade to Scala 2.9.1.

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -17,7 +17,7 @@ object SparkBuild extends Build {
   def sharedSettings = Defaults.defaultSettings ++ Seq(
     organization := "org.spark-project",
     version := "0.4-SNAPSHOT",
-    scalaVersion := "2.9.0-1",
+    scalaVersion := "2.9.1",
     scalacOptions := Seq(/*"-deprecation",*/ "-unchecked", "-optimize"), // -deprecation is too noisy due to usage of old Hadoop API, enable it once that's no longer an issue
     unmanagedJars in Compile <<= baseDirectory map { base => (base / "lib" ** "*.jar").classpath },
     retrieveManaged := true,

--- a/repl/src/main/scala/spark/repl/SparkIMain.scala
+++ b/repl/src/main/scala/spark/repl/SparkIMain.scala
@@ -356,7 +356,7 @@ class SparkIMain(val settings: Settings, protected val out: PrintWriter) extends
   private def mostRecentlyHandledTree: Option[Tree] = {
     prevRequests.reverse foreach { req =>
       req.handlers.reverse foreach {
-        case x: MemberDefHandler if x.definesValue && !isInternalVarName(x.name)  => return Some(x.member)
+        case x: MemberDefHandler if x.definesValue && !isInternalVarName(x.name.toString)  => return Some(x.member)
         case _ => ()
       }
     }
@@ -1023,7 +1023,7 @@ class SparkIMain(val settings: Settings, protected val out: PrintWriter) extends
   protected def onlyTerms(xs: List[Name]) = xs collect { case x: TermName => x }
   protected def onlyTypes(xs: List[Name]) = xs collect { case x: TypeName => x }
     
-  def definedTerms   = onlyTerms(allDefinedNames) filterNot isInternalVarName
+  def definedTerms   = onlyTerms(allDefinedNames) filterNot (x => isInternalVarName(x.toString))
   def definedTypes   = onlyTypes(allDefinedNames)
   def definedSymbols = prevRequests.toSet flatMap ((x: Request) => x.definedSymbols.values)
   

--- a/run
+++ b/run
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCALA_VERSION=2.9.0.1
+SCALA_VERSION=2.9.1.final
 
 # Figure out where the Scala framework is installed
 FWDIR="$(cd `dirname $0`; pwd)"


### PR DESCRIPTION
Scala 2.9.1 has been released and it includes a lot of improvements, including faster compilation:

http://www.scala-lang.org/node/10780

A couple of small changes in the REPL support were needed in addition to the changes in the build file and run script. Please review them to see if they're correct.

All tests pass and ./spark-shell launches successfully.
