### PR TITLE
Arthur: Replay debugger for Spark

### DIFF
--- a/bagel/src/main/scala/spark/bagel/examples/WikipediaPageRankStandalone.scala
+++ b/bagel/src/main/scala/spark/bagel/examples/WikipediaPageRankStandalone.scala
@@ -151,28 +151,23 @@ class WPRSerializationStream(os: OutputStream) extends SerializationStream {
   val jss = new JavaSerializationStream(os)
 
   def writeObject[T](t: T): Unit = t match {
-    case (id: String, wrapper: ArrayBuffer[_]) => wrapper(0) match {
-      case links: Array[String] => {
-        dos.writeInt(0) // links
-        dos.writeUTF(id)
-        dos.writeInt(links.length)
-        for (link <- links) {
-          dos.writeUTF(link)
-        }
+    case (id: String, ArrayBuffer(links: Array[String])) =>
+      dos.writeInt(0)
+      dos.writeUTF(id)
+      dos.writeInt(links.length)
+      for (link <- links) {
+        dos.writeUTF(link)
       }
-      case rank: Double => {
-        dos.writeInt(1) // rank
-        dos.writeUTF(id)
-        dos.writeDouble(rank)
-      }
-    }
-    case (id: String, rank: Double) => {
-      dos.writeInt(2) // rank without wrapper
+    case (id: String, ArrayBuffer(rank: Double)) =>
+      dos.writeInt(1)
       dos.writeUTF(id)
       dos.writeDouble(rank)
-    }
+    case (id: String, rank: Double) =>
+      dos.writeInt(2)
+      dos.writeUTF(id)
+      dos.writeDouble(rank)
     case _ =>
-      dos.writeInt(3) // anything else
+      dos.writeInt(3)
       dos.flush()
       jss.writeObject(t)
       jss.flush()

--- a/bagel/src/main/scala/spark/bagel/examples/WikipediaPageRankStandalone.scala
+++ b/bagel/src/main/scala/spark/bagel/examples/WikipediaPageRankStandalone.scala
@@ -12,14 +12,19 @@ import scala.collection.mutable.ArrayBuffer
 
 import java.io._
 
+/**
+ * Runs PageRank on the articles in the  given Freebase WEX-formatted
+ * dump of Wikipedia.
+ *
+ * For best performance, use the custom serializer by setting the
+ * spark.serializer property to spark.bagel.examples.WPRSerializer.
+ */
 object WikipediaPageRankStandalone {
   def main(args: Array[String]) {
     if (args.length < 5) {
       System.err.println("Usage: WikipediaPageRankStandalone <inputFile> <threshold> <numIterations> <host> <usePartitioner>")
       System.exit(-1)
     }
-
-    System.setProperty("spark.serializer", "spark.bagel.examples.WPRSerializer")
 
     val inputFile = args(0)
     val threshold = args(1).toDouble

--- a/core/src/main/scala/spark/AssertionRDDs.scala
+++ b/core/src/main/scala/spark/AssertionRDDs.scala
@@ -1,0 +1,66 @@
+package spark
+
+/**
+ * Passes each element of prev through unchanged, but also runs elementAssertion on each element and
+ * reports assertion failures.
+ */
+class ElementAssertionRDD[T: ClassManifest](
+  prev: RDD[T],
+  elementAssertion: (T, Split) => Option[AssertionFailure]
+) extends RDD[T](prev.context) {
+  override def splits = prev.splits
+  override val dependencies = List(new OneToOneDependency(prev))
+  override def compute(split: Split) = {
+    prev.iterator(split).map { (t: T) =>
+      for (failure <- elementAssertion(t, split)) {
+        SparkEnv.get.eventReporter.reportAssertionFailure(failure)
+      }
+      t
+    }
+  }
+  override def mapDependencies(g: RDD ~> RDD) = new ElementAssertionRDD(g(prev), elementAssertion)
+
+  reportCreation()
+}
+
+/**
+ * Passes each element of prev through unchanged, but also reduces the elements in each partition
+ * independently and reports assertion failures on the result.
+ */
+class ReduceAssertionRDD[T: ClassManifest](
+  prev: RDD[T],
+  reducer: (T, T) => T,
+  assertion: (T, Split) => Option[AssertionFailure]
+) extends RDD[T](prev.context) {
+  override def splits = prev.splits
+  override val dependencies = List(new OneToOneDependency(prev))
+  override def compute(split: Split) = new ReducingIterator(prev.iterator(split), split)
+  override def mapDependencies(g: RDD ~> RDD) = new ReduceAssertionRDD(g(prev), reducer, assertion)
+
+  class ReducingIterator(underlying: Iterator[T], split: Split) extends Iterator[T] {
+    def hasNext = underlying.hasNext
+    def next(): T =
+      if (hasNext) {
+        val result = underlying.next()
+        updateIntermediate(result)
+        if (!hasNext) checkAssertion()
+        result
+      } else {
+        throw new UnsupportedOperationException("no more elements")
+      }
+    private var intermediate: Option[T] = None
+    private def updateIntermediate(elem: T) {
+      intermediate = intermediate match {
+        case None => Some(elem)
+        case Some(x) => Some(reducer(x, elem))
+      }
+    }
+    private def checkAssertion() {
+      for (x <- intermediate; failure <- assertion(x, split)) {
+        SparkEnv.get.eventReporter.reportAssertionFailure(failure)
+      }
+    }
+  }
+
+  reportCreation()
+}

--- a/core/src/main/scala/spark/CartesianRDD.scala
+++ b/core/src/main/scala/spark/CartesianRDD.scala
@@ -45,6 +45,8 @@ class CartesianRDD[T: ClassManifest, U:ClassManifest](
     }
   )
 
+  override def mapDependencies(g: RDD ~> RDD) = new CartesianRDD(context, g(rdd1), g(rdd2))
+
   private def writeObject(stream: java.io.ObjectOutputStream) {
     stream.defaultWriteObject()
     stream match {

--- a/core/src/main/scala/spark/ChecksummingOutputStream.scala
+++ b/core/src/main/scala/spark/ChecksummingOutputStream.scala
@@ -1,0 +1,31 @@
+package spark
+
+import java.io._
+import scala.util.MurmurHash
+
+/**
+ * Wraps the given OutputStream, checksumming everything that gets written to it.
+ */
+class ChecksummingOutputStream(os: OutputStream) extends OutputStream {
+  val checksum = new MurmurHash[Byte](42) // constant seed so checksum is reproducible
+
+  override def write(b: Int) {
+    // Assume that b is really a Byte. This is part of the contract of
+    // OutputStream.
+    checksum(b.toByte)
+    os.write(b)
+  }
+
+  override def write(b: Array[Byte]) {
+    for (byte <- b) checksum(byte)
+    os.write(b)
+  }
+
+  override def flush() {
+    os.flush()
+  }
+
+  override def close() {
+    os.close()
+  }
+}

--- a/core/src/main/scala/spark/CoGroupedRDD.scala
+++ b/core/src/main/scala/spark/CoGroupedRDD.scala
@@ -41,6 +41,8 @@ class CoGroupedRDD[K](rdds: Seq[RDD[(_, _)]], part: Partitioner)
     }
     deps.toList
   }
+
+  override def mapDependencies(g: RDD ~> RDD) = new CoGroupedRDD(rdds.map(rdd => g(rdd)), part)
   
   @transient
   private var splits_ : Array[Split] = {

--- a/core/src/main/scala/spark/CoGroupedRDD.scala
+++ b/core/src/main/scala/spark/CoGroupedRDD.scala
@@ -43,7 +43,7 @@ class CoGroupedRDD[K](rdds: Seq[RDD[(_, _)]], part: Partitioner)
   }
   
   @transient
-  val splits_ : Array[Split] = {
+  private var splits_ : Array[Split] = {
     val firstRdd = rdds.head
     val array = new Array[Split](part.numPartitions)
     for (i <- 0 until array.size) {
@@ -91,4 +91,24 @@ class CoGroupedRDD[K](rdds: Seq[RDD[(_, _)]], part: Partitioner)
     }
     map.iterator
   }
+
+  private def writeObject(stream: java.io.ObjectOutputStream) {
+    stream.defaultWriteObject()
+    stream match {
+      case _: EventLogOutputStream =>
+        stream.writeObject(splits_)
+      case _ => {}
+    }
+  }
+
+  private def readObject(stream: java.io.ObjectInputStream) {
+    stream.defaultReadObject()
+    stream match {
+      case s: EventLogInputStream =>
+        splits_ = s.readObject().asInstanceOf[Array[Split]]
+      case _ => {}
+    }
+  }
+
+  reportCreation()
 }

--- a/core/src/main/scala/spark/DAGScheduler.scala
+++ b/core/src/main/scala/spark/DAGScheduler.scala
@@ -242,6 +242,7 @@ private trait DAGScheduler extends Scheduler with Logging {
         }
         myPending ++= tasks
         submitTasks(tasks, runId)
+        SparkEnv.get.eventReporter.reportTaskSubmission(tasks)
       }
   
       submitStage(finalStage)

--- a/core/src/main/scala/spark/DaemonThreadFactory.scala
+++ b/core/src/main/scala/spark/DaemonThreadFactory.scala
@@ -1,7 +1,5 @@
 package spark
 
-import akka.dispatch.ExecutorBasedEventDrivenDispatcher
-import akka.dispatch.MonitorableThreadFactory
 import java.util.concurrent.ThreadFactory
 
 /**
@@ -14,16 +12,3 @@ private object DaemonThreadFactory extends ThreadFactory {
     return t
   }
 }
-
-/**
- * Akka dispatcher that creates actors with daemon threads.
- */
-class DaemonDispatcher(name: String) extends {
-  override val threadFactory = new MonitorableThreadFactory(name) {
-    override def newThread(runnable: Runnable) = {
-      val thread = super.newThread(runnable)
-      thread.setDaemon(true)
-      thread
-    }
-  }
-} with ExecutorBasedEventDrivenDispatcher(name)

--- a/core/src/main/scala/spark/DaemonThreadFactory.scala
+++ b/core/src/main/scala/spark/DaemonThreadFactory.scala
@@ -1,5 +1,7 @@
 package spark
 
+import akka.dispatch.ExecutorBasedEventDrivenDispatcher
+import akka.dispatch.MonitorableThreadFactory
 import java.util.concurrent.ThreadFactory
 
 /**
@@ -12,3 +14,16 @@ private object DaemonThreadFactory extends ThreadFactory {
     return t
   }
 }
+
+/**
+ * Akka dispatcher that creates actors with daemon threads.
+ */
+class DaemonDispatcher(name: String) extends {
+  override val threadFactory = new MonitorableThreadFactory(name) {
+    override def newThread(runnable: Runnable) = {
+      val thread = super.newThread(runnable)
+      thread.setDaemon(true)
+      thread
+    }
+  }
+} with ExecutorBasedEventDrivenDispatcher(name)

--- a/core/src/main/scala/spark/DebuggingTaskRunner.scala
+++ b/core/src/main/scala/spark/DebuggingTaskRunner.scala
@@ -1,0 +1,80 @@
+package spark
+
+import com.google.common.io.Files
+import java.io._
+
+/**
+ * Loads the specified task from the event log and runs it locally, passing it the given input
+ * partition.
+ */
+object DebuggingTaskRunner {
+  def main(args: Array[String]) {
+    if (args.length < 4) {
+      System.err.println("Usage: DebuggingTaskRunner <eventLogPath> " +
+                         "<taskStageId> <taskPartition> <inputPath> " +
+                         "<host> [<sparkHome> [<JAR path> ...]]")
+      System.exit(1)
+    }
+
+    val eventLogPath = args(0)
+    val taskStageId = args(1).toInt
+    val taskPartition = args(2).toInt
+    val inputPath = args(3)
+    val host = args(4)
+    val sparkHome = if (args.length > 5) Option(args(5)) else None
+    val jars = args.slice(6, args.length)
+
+    val sc = new SparkContext(
+      host, "Task %d, %d".format(taskStageId, taskPartition),
+      sparkHome match {
+        case Some(x) => x
+        case None => null
+      }, jars)
+
+    val r = new EventLogReader(sc, Some(eventLogPath))
+
+    r.taskWithId(taskStageId, taskPartition) match {
+      case Some(task) =>
+        val ser = SparkEnv.get.serializer.newInstance()
+        val file = new File(inputPath)
+        val stream =
+          ser.inputStream(new BufferedInputStream(new FileInputStream(file)))
+        val iterator = new DeserializingIterator(stream)
+        task.run(0, iterator)
+        System.exit(0)
+      case None =>
+        System.err.println(
+          "Task ID (%d, %d) is not associated with a task!".format(
+            taskStageId, taskPartition))
+        System.exit(1)
+    }
+  }
+}
+
+/**
+ * Wraps a DeserializationStream into an Iterator.
+ */
+class DeserializingIterator(stream: DeserializationStream) extends Iterator[Any] {
+  def hasNext = !nextObject.isEmpty || readNext()
+  def next(): Any =
+    if (hasNext) {
+      val obj = nextObject.get
+      nextObject = None
+      obj
+    } else {
+      throw new UnsupportedOperationException("no more elements")
+    }
+
+  private var nextObject: Option[Any] = None
+  private def readNext(): Boolean = {
+    // Precondition: nextObject should be None
+    try {
+      nextObject = Option(stream.readObject())
+      !nextObject.isEmpty
+    } catch {
+      case _: EOFException =>
+        nextObject = None
+        false
+    }
+  }
+}

--- a/core/src/main/scala/spark/DebuggingTaskRunner.scala
+++ b/core/src/main/scala/spark/DebuggingTaskRunner.scala
@@ -2,79 +2,35 @@ package spark
 
 import com.google.common.io.Files
 import java.io._
+import spark.broadcast._
 
 /**
- * Loads the specified task from the event log and runs it locally, passing it the given input
- * partition.
+ * Loads the specified task from the event log and runs it locally.
  */
 object DebuggingTaskRunner {
   def main(args: Array[String]) {
-    if (args.length < 4) {
-      System.err.println("Usage: DebuggingTaskRunner <eventLogPath> " +
-                         "<taskStageId> <taskPartition> <inputPath> " +
-                         "<host> [<sparkHome> [<JAR path> ...]]")
+    if (args.length < 1) {
+      System.err.println("Usage: DebuggingTaskRunner <taskPath>")
       System.exit(1)
     }
 
-    val eventLogPath = args(0)
-    val taskStageId = args(1).toInt
-    val taskPartition = args(2).toInt
-    val inputPath = args(3)
-    val host = args(4)
-    val sparkHome = if (args.length > 5) Option(args(5)) else None
-    val jars = args.slice(6, args.length)
+    val taskPath = args(0)
 
-    val sc = new SparkContext(
-      host, "Task %d, %d".format(taskStageId, taskPartition),
-      sparkHome match {
-        case Some(x) => x
-        case None => null
-      }, jars)
+    // Initialize the environment similar to how the Mesos executor does
+    val env = SparkEnv.createFromSystemProperties(false)
+    SparkEnv.set(env)
+    Broadcast.initialize(false)
 
-    val r = new EventLogReader(sc, Some(eventLogPath))
+    // Deserialize the task
+    val file = new File(taskPath)
+    val ser = env.serializer.newInstance()
+    val in = ser.inputStream(new BufferedInputStream(new FileInputStream(file)))
+    val task = in.readObject[Task[_]]()
+    in.close()
 
-    r.taskWithId(taskStageId, taskPartition) match {
-      case Some(task) =>
-        val ser = SparkEnv.get.serializer.newInstance()
-        val file = new File(inputPath)
-        val stream =
-          ser.inputStream(new BufferedInputStream(new FileInputStream(file)))
-        val iterator = new DeserializingIterator(stream)
-        task.run(0, iterator)
-        System.exit(0)
-      case None =>
-        System.err.println(
-          "Task ID (%d, %d) is not associated with a task!".format(
-            taskStageId, taskPartition))
-        System.exit(1)
-    }
-  }
-}
+    // Run the task
+    task.run(0)
 
-/**
- * Wraps a DeserializationStream into an Iterator.
- */
-class DeserializingIterator(stream: DeserializationStream) extends Iterator[Any] {
-  def hasNext = !nextObject.isEmpty || readNext()
-  def next(): Any =
-    if (hasNext) {
-      val obj = nextObject.get
-      nextObject = None
-      obj
-    } else {
-      throw new UnsupportedOperationException("no more elements")
-    }
-
-  private var nextObject: Option[Any] = None
-  private def readNext(): Boolean = {
-    // Precondition: nextObject should be None
-    try {
-      nextObject = Option(stream.readObject())
-      !nextObject.isEmpty
-    } catch {
-      case _: EOFException =>
-        nextObject = None
-        false
-    }
+    System.exit(0)
   }
 }

--- a/core/src/main/scala/spark/DummyShuffledRDD.scala
+++ b/core/src/main/scala/spark/DummyShuffledRDD.scala
@@ -1,0 +1,35 @@
+package spark
+
+/**
+ * Dummy RDD used to wrap a ShuffleDependency in order to force the
+ * scheduler to execute the shuffle.
+ */
+class DummyShuffledRDD(dep: ShuffleDependency[_,_,_]) extends RDD[Nothing](dep.rdd.context) {
+  @transient
+  private var splits_ = Array.tabulate[Split](dep.partitioner.numPartitions)(i => new ShuffledRDDSplit(i))
+
+  override def splits = splits_
+  override val dependencies = List(dep)
+  override def mapDependencies(g: RDD ~> RDD) = throw new UnsupportedOperationException("not implemented")
+  override def compute(split: Split): Iterator[Nothing] = Iterator.empty
+
+  private def writeObject(stream: java.io.ObjectOutputStream) {
+    stream.defaultWriteObject()
+    stream match {
+      case _: EventLogOutputStream =>
+        stream.writeObject(splits_)
+      case _ => {}
+    }
+  }
+
+  private def readObject(stream: java.io.ObjectInputStream) {
+    stream.defaultReadObject()
+    stream match {
+      case s: EventLogInputStream =>
+        splits_ = s.readObject().asInstanceOf[Array[Split]]
+      case _ => {}
+    }
+  }
+
+  reportCreation()
+}

--- a/core/src/main/scala/spark/EventLogReader.scala
+++ b/core/src/main/scala/spark/EventLogReader.scala
@@ -58,6 +58,99 @@ class EventLogReader(sc: SparkContext, eventLogPath: Option[String] = None) {
       task <- tasks
     } yield task
 
+  /** Finds the tasks that were run to compute the given RDD. */
+  def tasksForRDD(rdd: RDD[_]): Seq[Task[_]] =
+    for {
+      task <- tasks
+      taskRDD <- task match {
+        case rt: ResultTask[_, _] => Some(rt.rdd)
+        case smt: ShuffleMapTask => Some(smt.rdd)
+        case _ => None
+      }
+      if taskRDD.id == rdd.id
+    } yield task
+
+  /** Finds the task for the given stage ID and partition. */
+  def taskWithId(stageId: Int, partition: Int): Option[Task[_]] =
+    (for {
+      task <- tasks
+      (taskStageId, taskPartition) <- task match {
+        case rt: ResultTask[_, _] => Some((rt.stageId, rt.partition))
+        case smt: ShuffleMapTask => Some((smt.stageId, smt.partition))
+        case _ => None
+      }
+      if taskStageId == stageId && taskPartition == partition
+    } yield task).headOption
+
+  /**
+   * Runs the specified task locally in a new JVM with the given options, and blocks until the task
+   * has completed. While the task is running, it takes over the input and output streams.
+   */
+  def debugTask(taskStageId: Int, taskPartition: Int, debugOpts: Option[String] = None) {
+    for {
+      elp <- eventLogPath orElse { Option(System.getProperty("spark.arthur.logPath")) }
+      sparkHome <- Option(sc.sparkHome) orElse { Option("") }
+      task <- taskWithId(taskStageId, taskPartition)
+      (rdd, partition) <- task match {
+        case rt: ResultTask[_, _] => Some((rt.rdd, rt.partition))
+        case smt: ShuffleMapTask => Some((smt.rdd, smt.partition))
+        case _ => None
+      }
+      debugOptsString <- debugOpts orElse {
+        Option("-Xdebug -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8000")
+      }
+    } try {
+      val ser = SparkEnv.get.serializer.newInstance()
+      val tempDir = Files.createTempDir()
+      val file = new File(tempDir, "debugTask-%d-%d".format(taskStageId, taskPartition))
+      val out = ser.outputStream(new BufferedOutputStream(new FileOutputStream(file)))
+      println("Computing input for task %s into %s".format(task, file))
+      val elems = sc.runJob(rdd, (iter: Iterator[_]) => iter.toArray, List(partition), true)
+      for (elem <- elems(0)) {
+        out.writeObject(elem)
+      }
+      out.close()
+
+      println("Running task " + task)
+
+      // Launch the task in a separate JVM with debug options set
+      val pb = new ProcessBuilder(List(
+        "./run", "spark.DebuggingTaskRunner", elp, taskStageId.toString,
+        taskPartition.toString, file.getPath, sc.master, sparkHome
+      ) ::: sc.jars.toList)
+      pb.environment.put("SPARK_DEBUG_OPTS", debugOptsString)
+      pb.redirectErrorStream(true)
+      val proc = pb.start()
+
+      // Pipe the task's stdout and stderr to our own
+      new Thread {
+        override def run {
+          val procStdout = proc.getInputStream
+          var byte: Int = procStdout.read()
+          while (byte != -1) {
+            System.out.write(byte)
+            byte = procStdout.read()
+          }
+        }
+      }.start()
+      proc.waitFor()
+      println("Finished running task " + task)
+    } catch {
+      case ex => println("Failed to run task %s: %s".format(task, ex))
+    }
+  }
+
+  /** Runs the task that caused the specified exception locally. See debugTask. */
+  def debugException(event: ExceptionEvent, debugOpts: Option[String] = None) {
+    for ((taskStageId, taskPartition) <- event.task match {
+      case rt: ResultTask[_, _] => Some((rt.stageId, rt.partition))
+      case smt: ShuffleMapTask => Some((smt.stageId, smt.partition))
+      case _ => None
+    }) {
+      debugTask(taskStageId, taskPartition, debugOpts)
+    }
+  }
+
   /** Reads any new events from the event log. */
   def loadNewEvents() {
     for (ois <- objectInputStream) {

--- a/core/src/main/scala/spark/EventLogReader.scala
+++ b/core/src/main/scala/spark/EventLogReader.scala
@@ -1,0 +1,82 @@
+package spark
+
+import com.google.common.io.Files
+import java.io._
+import scala.collection.JavaConversions._
+import scala.collection.mutable.ArrayBuffer
+
+/**
+ * Reads events from an event log on disk and processes them.
+ */
+class EventLogReader(sc: SparkContext, eventLogPath: Option[String] = None) {
+  val objectInputStream = for {
+    elp <- eventLogPath orElse { Option(System.getProperty("spark.arthur.logPath")) }
+    file = new File(elp)
+    if file.exists
+  } yield new EventLogInputStream(new FileInputStream(file), sc)
+  val events = new ArrayBuffer[EventLogEntry]
+  private val _rdds: ArrayBuffer[RDD[_]] = new ArrayBuffer[RDD[_]]
+  loadNewEvents()
+
+  /** List of RDDs from the event log, indexed by their IDs. */
+  def rdds = _rdds.readOnly
+
+  /** Prints a human-readable list of RDDs. */
+  def printRDDs() {
+    for (RDDCreation(rdd, location) <- events) {
+      println("#%02d: %-20s %s".format(rdd.id, rddType(rdd), firstExternalElement(location)))
+    }
+  }
+
+  /** Returns the path of a PDF file containing a visualization of the RDD graph. */
+  def visualizeRDDs(): String = {
+    val file = File.createTempFile("spark-rdds-", "")
+    val dot = new java.io.PrintWriter(file)
+    dot.println("digraph {")
+    for (RDDCreation(rdd, location) <- events) {
+      dot.println("  %d [label=\"%d %s\"]".format(rdd.id, rdd.id, rddType(rdd)))
+      for (dep <- rdd.dependencies) {
+        dot.println("  %d -> %d;".format(rdd.id, dep.rdd.id))
+      }
+    }
+    dot.println("}")
+    dot.close()
+    Runtime.getRuntime.exec("dot -Grankdir=BT -Tpdf " + file + " -o " + file + ".pdf")
+    file + ".pdf"
+  }
+
+  /** List of all tasks. */
+  def tasks: Seq[Task[_]] =
+    for {
+      TaskSubmission(tasks) <- events
+      task <- tasks
+    } yield task
+
+  /** Reads any new events from the event log. */
+  def loadNewEvents() {
+    for (ois <- objectInputStream) {
+      try {
+        while (true) {
+          val event = ois.readObject.asInstanceOf[EventLogEntry]
+          events += event
+          event match {
+            case RDDCreation(rdd, location) =>
+              sc.updateRddId(rdd.id)
+              _rdds += rdd
+            case _ => {}
+          }
+        }
+      } catch {
+        case e: EOFException => {}
+      }
+    }
+  }
+
+  private def firstExternalElement(location: Array[StackTraceElement]) =
+    (location.tail.find(!_.getClassName.matches("""spark\.[A-Z].*"""))
+      orElse { location.headOption }
+      getOrElse { "" })
+
+  private def rddType(rdd: RDD[_]): String =
+    rdd.getClass.getName.replaceFirst("""^spark\.""", "")
+}

--- a/core/src/main/scala/spark/EventLogWriter.scala
+++ b/core/src/main/scala/spark/EventLogWriter.scala
@@ -38,6 +38,13 @@ class EventLogWriter extends Logging {
       recordedChecksum @ (_x: ChecksumEvent) <- r.events
       if checksum mismatch recordedChecksum
     } r.reportChecksumMismatch(recordedChecksum, checksum)
+
+    // If the entry is an AssertionFailure, add it to the events in the EventLogReader. This makes
+    // it possible to add and check assertions while debugging.
+    for (r <- eventLogReader) entry match {
+      case f: AssertionFailure => r.events += f
+      case _ => {}
+    }
   }
 
   def flush() {

--- a/core/src/main/scala/spark/EventLogWriter.scala
+++ b/core/src/main/scala/spark/EventLogWriter.scala
@@ -1,0 +1,41 @@
+package spark
+
+import java.io._
+
+/**
+ * Writes events to an event log on disk, cooperating with EventLogReader to perform checksum
+ * verification if appropriate.
+ */
+class EventLogWriter extends Logging {
+  private var eventLog: Option[EventLogOutputStream] = None
+  setEventLogPath(Option(System.getProperty("spark.arthur.logPath")))
+  private var eventLogReader: Option[EventLogReader] = None
+
+  def setEventLogPath(eventLogPath: Option[String]) {
+    eventLog =
+      for {
+        elp <- eventLogPath
+        file = new File(elp)
+        if !file.exists
+      } yield new EventLogOutputStream(new FileOutputStream(file))
+  }
+
+  def log(entry: EventLogEntry) {
+    // Log the entry
+    for (l <- eventLog) {
+      l.writeObject(entry)
+    }
+  }
+
+  def flush() {
+    for (l <- eventLog) {
+      l.flush()
+    }
+  }
+
+  def stop() {
+    for (l <- eventLog) {
+      l.close()
+    }
+  }
+}

--- a/core/src/main/scala/spark/EventLogging.scala
+++ b/core/src/main/scala/spark/EventLogging.scala
@@ -7,6 +7,7 @@ import java.io._
  */
 sealed trait EventLogEntry
 
+case class ExceptionEvent(exception: Throwable, task: Task[_]) extends EventLogEntry
 case class RDDCreation(rdd: RDD[_], location: Array[StackTraceElement]) extends EventLogEntry
 case class TaskSubmission(tasks: Seq[Task[_]]) extends EventLogEntry
 

--- a/core/src/main/scala/spark/EventLogging.scala
+++ b/core/src/main/scala/spark/EventLogging.scala
@@ -1,0 +1,29 @@
+package spark
+
+import java.io._
+
+/**
+ * Spark program event that can be logged during execution and later replayed using Arthur.
+ */
+sealed trait EventLogEntry
+
+case class RDDCreation(rdd: RDD[_], location: Array[StackTraceElement]) extends EventLogEntry
+case class TaskSubmission(tasks: Seq[Task[_]]) extends EventLogEntry
+
+/**
+ * Stream for writing the event log.
+ *
+ * Certain classes may need to write certain transient fields to the event log. Such classes should
+ * implement a special writeObject method (see java.io.Serializable) that takes a
+ * java.io.ObjectOutputStream as an argument. They should check the argument's dynamic type; if it
+ * is an EventLogOutputStream, they should write the extra fields.
+ */
+class EventLogOutputStream(out: OutputStream) extends ObjectOutputStream(out)
+
+/**
+ * Stream for reading the event log. See EventLogOutputStream.
+ */
+class EventLogInputStream(in: InputStream, val sc: SparkContext) extends ObjectInputStream(in) {
+  override def resolveClass(desc: ObjectStreamClass) =
+    Class.forName(desc.getName, false, Thread.currentThread.getContextClassLoader)
+}

--- a/core/src/main/scala/spark/EventLogging.scala
+++ b/core/src/main/scala/spark/EventLogging.scala
@@ -37,6 +37,10 @@ case class ShuffleChecksum(
   }
 }
 
+sealed trait AssertionFailure extends EventLogEntry
+case class ElementAssertionFailure(rddId: Int, element: Any) extends AssertionFailure
+case class ReduceAssertionFailure(rddId: Int, splitIndex: Int, element: Any) extends AssertionFailure
+
 /**
  * Stream for writing the event log.
  *

--- a/core/src/main/scala/spark/EventReporter.scala
+++ b/core/src/main/scala/spark/EventReporter.scala
@@ -1,0 +1,75 @@
+package spark
+
+import akka.actor.Actor
+import akka.actor.Actor._
+import akka.actor.ActorRef
+import akka.dispatch.MessageDispatcher
+import java.io._
+
+sealed trait EventReporterMessage
+case class LogEvent(entry: EventLogEntry) extends EventReporterMessage
+case class StopEventReporter() extends EventReporterMessage
+
+class EventReporterActor(dispatcher: MessageDispatcher, eventLogWriter: EventLogWriter) extends Actor with Logging {
+  self.dispatcher = dispatcher
+
+  def receive = {
+    case LogEvent(entry) =>
+      eventLogWriter.log(entry)
+    case StopEventReporter =>
+      eventLogWriter.stop()
+      self.reply('OK)
+  }
+}
+
+/**
+ * Manages event reporting on the master and slaves.
+ */
+class EventReporter(isMaster: Boolean, dispatcher: MessageDispatcher) extends Logging {
+  var enableArthur = System.getProperty("spark.arthur.enabled", "true").toBoolean
+  val host = System.getProperty("spark.master.host")
+
+  var eventLogWriter: Option[EventLogWriter] = None
+  /** Remote reference to the actor on workers. */
+  var reporterActor: Option[ActorRef] = None
+  init()
+
+  def init() {
+    eventLogWriter =
+      if (isMaster && enableArthur) Some(new EventLogWriter)
+      else None
+    reporterActor =
+      if (enableArthur) {
+        for (elw <- eventLogWriter) {
+          remote.register("EventReporter", actorOf(new EventReporterActor(dispatcher, elw)))
+        }
+        val port = System.getProperty("spark.master.akkaPort").toInt
+        logInfo("Binding to Akka at %s:%d".format(host, port))
+        Some(remote.actorFor("EventReporter", host, port))
+      } else {
+        None
+      }
+  }
+
+  /** Reports the creation of an RDD. Can only be called on the master. */
+  def reportRDDCreation(rdd: RDD[_], location: Array[StackTraceElement]) {
+    for (elw <- eventLogWriter) {
+      elw.log(RDDCreation(rdd, location))
+    }
+  }
+
+  /** Reports the creation of a task. Can only be called on the master. */
+  def reportTaskSubmission(tasks: Seq[Task[_]]) {
+    for (elw <- eventLogWriter) {
+      elw.log(TaskSubmission(tasks))
+    }
+  }
+
+  def stop() {
+    for (r <- reporterActor) {
+      r ? StopEventReporter
+    }
+    eventLogWriter = None
+    reporterActor = None
+  }
+}

--- a/core/src/main/scala/spark/EventReporter.scala
+++ b/core/src/main/scala/spark/EventReporter.scala
@@ -52,6 +52,11 @@ class EventReporter(isMaster: Boolean, dispatcher: MessageDispatcher) extends Lo
       }
   }
 
+  /** Reports the failure of an RDD assertion. */
+  def reportAssertionFailure(failure: AssertionFailure) {
+    reporterActor ! LogEvent(failure)
+  }
+
   /** Reports an exception when running a task on a slave. */
   def reportException(exception: Throwable, task: Task[_]) {
     // TODO: The task may refer to an RDD, so sending it through the actor will interfere with RDD

--- a/core/src/main/scala/spark/EventReporter.scala
+++ b/core/src/main/scala/spark/EventReporter.scala
@@ -1,60 +1,68 @@
 package spark
 
-import akka.actor.Actor
-import akka.actor.Actor._
-import akka.actor.ActorRef
-import akka.dispatch.MessageDispatcher
+import scala.actors._
+import scala.actors.Actor._
+import scala.actors.remote._
 import java.io._
 
 sealed trait EventReporterMessage
 case class LogEvent(entry: EventLogEntry) extends EventReporterMessage
 case class StopEventReporter() extends EventReporterMessage
 
-class EventReporterActor(dispatcher: MessageDispatcher, eventLogWriter: EventLogWriter) extends Actor with Logging {
-  self.dispatcher = dispatcher
+class EventReporterActor(eventLogWriter: EventLogWriter) extends DaemonActor with Logging {
+  def act() {
+    val port = System.getProperty("spark.master.port").toInt
+    RemoteActor.alive(port)
+    RemoteActor.register('EventReporterActor, self)
+    logInfo("Registered actor on port " + port)
 
-  def receive = {
-    case LogEvent(entry) =>
-      eventLogWriter.log(entry)
-    case StopEventReporter =>
-      eventLogWriter.stop()
-      self.reply('OK)
+    loop {
+      react {
+        case LogEvent(entry) =>
+          eventLogWriter.log(entry)
+        case StopEventReporter =>
+          eventLogWriter.stop()
+          reply('OK)
+      }
+    }
   }
 }
 
 /**
  * Manages event reporting on the master and slaves.
  */
-class EventReporter(isMaster: Boolean, dispatcher: MessageDispatcher) extends Logging {
+class EventReporter(isMaster: Boolean) extends Logging {
   var enableArthur = System.getProperty("spark.arthur.enabled", "true").toBoolean
   var enableChecksumming = System.getProperty("spark.arthur.checksum", "true").toBoolean
   val host = System.getProperty("spark.master.host")
 
   var eventLogWriter: Option[EventLogWriter] = None
   /** Remote reference to the actor on workers. */
-  var reporterActor: Option[ActorRef] = None
+  var reporterActor: AbstractActor = null
   init()
 
   def init() {
     eventLogWriter =
       if (isMaster && enableArthur) Some(new EventLogWriter)
       else None
-    reporterActor =
-      if (enableArthur) {
+    if (enableArthur) {
+      if (isMaster) {
         for (elw <- eventLogWriter) {
-          remote.register("EventReporter", actorOf(new EventReporterActor(dispatcher, elw)))
+          val actor = new EventReporterActor(elw)
+          actor.start()
+          reporterActor = actor
         }
-        val port = System.getProperty("spark.master.akkaPort").toInt
-        logInfo("Binding to Akka at %s:%d".format(host, port))
-        Some(remote.actorFor("EventReporter", host, port))
       } else {
-        None
+        val host = System.getProperty("spark.master.host")
+        val port = System.getProperty("spark.master.port").toInt
+        reporterActor = RemoteActor.select(Node(host, port), 'EventReporterActor)
       }
+    }
   }
 
   /** Reports the failure of an RDD assertion. */
   def reportAssertionFailure(failure: AssertionFailure) {
-    reporterActor ! LogEvent(failure)
+    reporterActor !! LogEvent(failure)
   }
 
   /** Reports an exception when running a task on a slave. */
@@ -62,7 +70,7 @@ class EventReporter(isMaster: Boolean, dispatcher: MessageDispatcher) extends Lo
     // TODO: The task may refer to an RDD, so sending it through the actor will interfere with RDD
     // back-referencing, causing a duplicate version of the referenced RDD to be serialized. If
     // tasks had IDs, we could just send those.
-    reporterActor ! LogEvent(ExceptionEvent(exception, task))
+    reporterActor !! LogEvent(ExceptionEvent(exception, task))
   }
 
   /**
@@ -91,19 +99,17 @@ class EventReporter(isMaster: Boolean, dispatcher: MessageDispatcher) extends Lo
 
   /** Reports the checksum of a task's results. */
   def reportTaskChecksum(tid: Int, checksum: Int) {
-    reporterActor ! LogEvent(TaskChecksum(tid, checksum))
+    reporterActor !! LogEvent(TaskChecksum(tid, checksum))
   }
 
   /** Reports the checksum of a shuffle output. */
   def reportShuffleChecksum(rdd: RDD[_], shuffleId: Int, partition: Int, outputSplit: Int, checksum: Int) {
-    reporterActor ! LogEvent(ShuffleChecksum(rdd.id, shuffleId, partition, outputSplit, checksum))
+    reporterActor !! LogEvent(ShuffleChecksum(rdd.id, shuffleId, partition, outputSplit, checksum))
   }
 
   def stop() {
-    for (r <- reporterActor) {
-      r ? StopEventReporter
-    }
+    reporterActor !? StopEventReporter
     eventLogWriter = None
-    reporterActor = None
+    reporterActor = null
   }
 }

--- a/core/src/main/scala/spark/Executor.scala
+++ b/core/src/main/scala/spark/Executor.scala
@@ -101,6 +101,7 @@ class Executor extends org.apache.mesos.Executor with Logging {
               .setState(TaskState.TASK_FAILED)
               .setData(ByteString.copyFrom(Utils.serialize(reason)))
               .build())
+          env.eventReporter.reportException(t, task)
 
           // TODO: Handle errors in tasks less dramatically
           logError("Exception in task ID " + tid, t)

--- a/core/src/main/scala/spark/HadoopRDD.scala
+++ b/core/src/main/scala/spark/HadoopRDD.scala
@@ -111,6 +111,8 @@ class HadoopRDD[K, V](
   
   override val dependencies: List[Dependency[_]] = Nil
 
+  override def mapDependencies(g: RDD ~> RDD) = this
+
   private def writeObject(stream: java.io.ObjectOutputStream) {
     stream.defaultWriteObject()
     stream match {

--- a/core/src/main/scala/spark/LocalScheduler.scala
+++ b/core/src/main/scala/spark/LocalScheduler.scala
@@ -58,6 +58,7 @@ private class LocalScheduler(threads: Int, maxFailures: Int) extends DAGSchedule
       } catch {
         case t: Throwable => {
           logError("Exception in task " + idInJob, t)
+          env.eventReporter.reportLocalException(t, task)
           failCount.synchronized {
             failCount(idInJob) += 1
             if (failCount(idInJob) <= maxFailures) {

--- a/core/src/main/scala/spark/NewHadoopRDD.scala
+++ b/core/src/main/scala/spark/NewHadoopRDD.scala
@@ -91,6 +91,8 @@ class NewHadoopRDD[K, V](
 
   override val dependencies: List[Dependency[_]] = Nil
 
+  override def mapDependencies(g: RDD ~> RDD) = this
+
   private def writeObject(stream: java.io.ObjectOutputStream) {
     stream.defaultWriteObject()
     stream match {

--- a/core/src/main/scala/spark/PairRDDFunctions.scala
+++ b/core/src/main/scala/spark/PairRDDFunctions.scala
@@ -380,6 +380,7 @@ class PairRDDFunctions[K: ClassManifest, V: ClassManifest](
       prev.iterator(split).toArray
         .sortWith((x, y) => if (ascending) x._1 < y._1 else x._1 > y._1).iterator
     }
+    reportCreation()
   } 
  
 class MappedValuesRDD[K, V, U](prev: RDD[(K, V)], f: V => U) extends RDD[(K, U)](prev.context) {
@@ -387,6 +388,7 @@ class MappedValuesRDD[K, V, U](prev: RDD[(K, V)], f: V => U) extends RDD[(K, U)]
   override val dependencies = List(new OneToOneDependency(prev))
   override val partitioner = prev.partitioner
   override def compute(split: Split) = prev.iterator(split).map{case (k, v) => (k, f(v))}
+  reportCreation()
 }
 
 class FlatMappedValuesRDD[K, V, U](prev: RDD[(K, V)], f: V => Traversable[U])
@@ -400,6 +402,7 @@ class FlatMappedValuesRDD[K, V, U](prev: RDD[(K, V)], f: V => Traversable[U])
       case (k, v) => f(v).map(x => (k, x))
     }.iterator
   }
+  reportCreation()
 }
 
 object Manifests {

--- a/core/src/main/scala/spark/ParallelCollection.scala
+++ b/core/src/main/scala/spark/ParallelCollection.scala
@@ -44,6 +44,8 @@ class ParallelCollection[T: ClassManifest](
   
   override val dependencies: List[Dependency[_]] = Nil
 
+  override def mapDependencies(g: RDD ~> RDD) = this
+
   private def writeObject(stream: java.io.ObjectOutputStream) {
     stream.defaultWriteObject()
     stream match {

--- a/core/src/main/scala/spark/ParallelShuffleFetcher.scala
+++ b/core/src/main/scala/spark/ParallelShuffleFetcher.scala
@@ -31,7 +31,7 @@ class ParallelShuffleFetcher extends ShuffleFetcher with Logging {
     
     // Randomize them and put them in a LinkedBlockingQueue
     val serverQueue = new LinkedBlockingQueue[(String, ArrayBuffer[Int])]
-    for (pair <- Utils.randomize(inputsByUri)) {
+    for (pair <- Utils.randomize(inputsByUri, seed(shuffleId, reduceId))) {
       serverQueue.put(pair)
     }
 

--- a/core/src/main/scala/spark/PipedRDD.scala
+++ b/core/src/main/scala/spark/PipedRDD.scala
@@ -20,6 +20,8 @@ class PipedRDD[T: ClassManifest](parent: RDD[T], command: Seq[String])
 
   override val dependencies = List(new OneToOneDependency(parent))
 
+  override def mapDependencies(g: RDD ~> RDD) = new PipedRDD(g(parent), command)
+
   override def compute(split: Split): Iterator[String] = {
     val proc = Runtime.getRuntime.exec(command.toArray)
     val env = SparkEnv.get

--- a/core/src/main/scala/spark/PipedRDD.scala
+++ b/core/src/main/scala/spark/PipedRDD.scala
@@ -48,6 +48,8 @@ class PipedRDD[T: ClassManifest](parent: RDD[T], command: Seq[String])
     // Return an iterator that read lines from the process's stdout
     Source.fromInputStream(proc.getInputStream).getLines
   }
+
+  reportCreation()
 }
 
 object PipedRDD {

--- a/core/src/main/scala/spark/ResultTask.scala
+++ b/core/src/main/scala/spark/ResultTask.scala
@@ -12,11 +12,9 @@ class ResultTask[T, U](
   
   val split = rdd.splits(partition)
 
-  override def input: Iterator[T] = rdd.iterator(split)
-
-  override def run(attemptId: Int, input: Iterator[_]): U = {
+  override def run(attemptId: Int): U = {
     val context = new TaskContext(stageId, partition, attemptId)
-    func(context, input.asInstanceOf[Iterator[T]])
+    func(context, rdd.iterator(split))
   }
 
   override def preferredLocations: Seq[String] = locs

--- a/core/src/main/scala/spark/ResultTask.scala
+++ b/core/src/main/scala/spark/ResultTask.scala
@@ -4,7 +4,7 @@ class ResultTask[T, U](
     runId: Int,
     stageId: Int,
     val rdd: RDD[T],
-    func: (TaskContext, Iterator[T]) => U,
+    val func: (TaskContext, Iterator[T]) => U,
     val partition: Int,
     locs: Seq[String],
     val outputId: Int)

--- a/core/src/main/scala/spark/ResultTask.scala
+++ b/core/src/main/scala/spark/ResultTask.scala
@@ -2,19 +2,21 @@ package spark
 
 class ResultTask[T, U](
     runId: Int,
-    stageId: Int, 
-    rdd: RDD[T], 
+    stageId: Int,
+    val rdd: RDD[T],
     func: (TaskContext, Iterator[T]) => U,
-    val partition: Int, 
+    val partition: Int,
     locs: Seq[String],
     val outputId: Int)
   extends DAGTask[U](runId, stageId) {
   
   val split = rdd.splits(partition)
 
-  override def run(attemptId: Int): U = {
+  override def input: Iterator[T] = rdd.iterator(split)
+
+  override def run(attemptId: Int, input: Iterator[_]): U = {
     val context = new TaskContext(stageId, partition, attemptId)
-    func(context, rdd.iterator(split))
+    func(context, input.asInstanceOf[Iterator[T]])
   }
 
   override def preferredLocations: Seq[String] = locs

--- a/core/src/main/scala/spark/SampledRDD.scala
+++ b/core/src/main/scala/spark/SampledRDD.scala
@@ -14,7 +14,7 @@ class SampledRDD[T: ClassManifest](
   extends RDD[T](prev.context) {
 
   @transient
-  val splits_ = {
+  private var splits_ = {
     val rg = new Random(seed);
     prev.splits.map(x => new SampledRDDSplit(x, rg.nextInt))
   }
@@ -43,4 +43,24 @@ class SampledRDD[T: ClassManifest](
       prev.iterator(split.prev).filter(x => (rg.nextDouble <= frac))
     }
   }
+
+  private def writeObject(stream: java.io.ObjectOutputStream) {
+    stream.defaultWriteObject()
+    stream match {
+      case _: EventLogOutputStream =>
+        stream.writeObject(splits_)
+      case _ => {}
+    }
+  }
+
+  private def readObject(stream: java.io.ObjectInputStream) {
+    stream.defaultReadObject()
+    stream match {
+      case s: EventLogInputStream =>
+        splits_ = s.readObject().asInstanceOf[Array[SampledRDDSplit]]
+      case _ => {}
+    }
+  }
+
+  reportCreation()
 }

--- a/core/src/main/scala/spark/SampledRDD.scala
+++ b/core/src/main/scala/spark/SampledRDD.scala
@@ -22,6 +22,8 @@ class SampledRDD[T: ClassManifest](
   override def splits = splits_.asInstanceOf[Array[Split]]
 
   override val dependencies = List(new OneToOneDependency(prev))
+
+  override def mapDependencies(g: RDD ~> RDD) = new SampledRDD(g(prev), withReplacement, frac, seed)
   
   override def preferredLocations(split: Split) =
     prev.preferredLocations(split.asInstanceOf[SampledRDDSplit].prev)

--- a/core/src/main/scala/spark/ShuffleFetcher.scala
+++ b/core/src/main/scala/spark/ShuffleFetcher.scala
@@ -5,6 +5,10 @@ abstract class ShuffleFetcher {
   // once on each key-value pair obtained.
   def fetch[K, V](shuffleId: Int, reduceId: Int, func: (K, V) => Unit)
 
+  /** Deterministically computes a seed for randomizing the order of shuffle fetching. */
+  protected def seed(shuffleId: Int, reduceId: Int): Long =
+    (shuffleId.toLong << 32) + reduceId.toLong
+
   // Stop the fetcher
   def stop() {}
 }

--- a/core/src/main/scala/spark/ShuffleMapTask.scala
+++ b/core/src/main/scala/spark/ShuffleMapTask.scala
@@ -19,14 +19,12 @@ class ShuffleMapTask(
   
   val split = rdd.splits(partition)
 
-  override def input: Iterator[_] = rdd.iterator(split)
-
-  override def run(attemptId: Int, input: Iterator[_]): String = {
+  override def run(attemptId: Int): String = {
     val numOutputSplits = dep.partitioner.numPartitions
     val aggregator = dep.aggregator.asInstanceOf[Aggregator[Any, Any, Any]]
     val partitioner = dep.partitioner.asInstanceOf[Partitioner]
     val buckets = Array.tabulate(numOutputSplits)(_ => new JHashMap[Any, Any])
-    for (elem <- input) {
+    for (elem <- rdd.iterator(split)) {
       val (k, v) = elem.asInstanceOf[(Any, Any)]
       var bucketId = partitioner.getPartition(k)
       val bucket = buckets(bucketId)

--- a/core/src/main/scala/spark/ShuffleMapTask.scala
+++ b/core/src/main/scala/spark/ShuffleMapTask.scala
@@ -4,7 +4,6 @@ import java.io.BufferedOutputStream
 import java.io.FileOutputStream
 import java.io.ObjectOutputStream
 import java.util.{HashMap => JHashMap}
-import scala.util.MurmurHash
 
 import it.unimi.dsi.fastutil.io.FastBufferedOutputStream
 
@@ -13,7 +12,7 @@ class ShuffleMapTask(
     stageId: Int,
     val rdd: RDD[_],
     dep: ShuffleDependency[_,_,_],
-    val partition: Int, 
+    val partition: Int,
     locs: Seq[String])
   extends DAGTask[String](runId, stageId)
   with Logging {
@@ -41,26 +40,27 @@ class ShuffleMapTask(
     val ser = SparkEnv.get.serializer.newInstance()
     for (i <- 0 until numOutputSplits) {
       val file = SparkEnv.get.shuffleManager.getOutputFile(dep.shuffleId, partition, i)
-      val out = ser.outputStream(new FastBufferedOutputStream(new FileOutputStream(file)))
+      val fbos = new FastBufferedOutputStream(new FileOutputStream(file))
+      val cos =
+        if (SparkEnv.get.eventReporter.enableChecksumming) Some(new ChecksummingOutputStream(fbos))
+        else None
+      val out = cos match {
+        case Some(c) => ser.outputStream(c)
+        case None => ser.outputStream(fbos)
+      }
       val iter = buckets(i).entrySet().iterator()
 
-      if (SparkEnv.get.eventReporter.enableChecksumming) {
-        val checksum = new MurmurHash[(Any, Any)](42) // constant seed so checksum is reproducible
-        while (iter.hasNext()) {
-          val entry = iter.next()
-          val pair = (entry.getKey, entry.getValue)
-          out.writeObject(pair)
-          checksum(pair)
-        }
-        SparkEnv.get.eventReporter.reportShuffleChecksum(rdd, dep.shuffleId, partition, i, checksum.hash)
-      } else {
-        while (iter.hasNext()) {
-          val entry = iter.next()
-          out.writeObject((entry.getKey, entry.getValue))
-        }
+      while (iter.hasNext()) {
+        val entry = iter.next()
+        out.writeObject((entry.getKey, entry.getValue))
       }
+
       // TODO: have some kind of EOF marker
       out.close()
+
+      for (c <- cos) {
+        SparkEnv.get.eventReporter.reportShuffleChecksum(rdd, partition, i, c.checksum.hash)
+      }
     }
     return SparkEnv.get.shuffleManager.getServerUri
   }

--- a/core/src/main/scala/spark/ShuffledRDD.scala
+++ b/core/src/main/scala/spark/ShuffledRDD.scala
@@ -25,6 +25,8 @@ class ShuffledRDD[K, V, C](
   val dep = new ShuffleDependency(context.newShuffleId, parent, aggregator, part)
   override val dependencies = List(dep)
 
+  override def mapDependencies(g: RDD ~> RDD) = new ShuffledRDD(g(parent), aggregator, part)
+
   override def compute(split: Split): Iterator[(K, C)] = {
     val combiners = new JHashMap[K, C]
     def mergePair(k: K, c: C) {

--- a/core/src/main/scala/spark/SimpleShuffleFetcher.scala
+++ b/core/src/main/scala/spark/SimpleShuffleFetcher.scala
@@ -17,7 +17,7 @@ class SimpleShuffleFetcher extends ShuffleFetcher with Logging {
     for ((serverUri, index) <- serverUris.zipWithIndex) {
       splitsByUri.getOrElseUpdate(serverUri, ArrayBuffer()) += index
     }
-    for ((serverUri, inputIds) <- Utils.randomize(splitsByUri)) {
+    for ((serverUri, inputIds) <- Utils.randomize(splitsByUri, seed(shuffleId, reduceId))) {
       for (i <- inputIds) {
         try {
           val url = "%s/shuffle/%d/%d/%d".format(serverUri, shuffleId, i, reduceId)

--- a/core/src/main/scala/spark/SparkContext.scala
+++ b/core/src/main/scala/spark/SparkContext.scala
@@ -31,8 +31,8 @@ import org.apache.hadoop.mapreduce.{Job => NewHadoopJob}
 import spark.broadcast._
 
 class SparkContext(
-    private[spark] val master: String,
-    private[spark] val frameworkName: String,
+    val master: String,
+    val frameworkName: String,
     val sparkHome: String = null,
     val jars: Seq[String] = Nil)
   extends Logging {

--- a/core/src/main/scala/spark/SparkContext.scala
+++ b/core/src/main/scala/spark/SparkContext.scala
@@ -242,6 +242,7 @@ class SparkContext(
     env.cacheTracker.stop()
     env.shuffleFetcher.stop()
     env.shuffleManager.stop()
+    env.eventReporter.stop()
     SparkEnv.set(null)
   }
 
@@ -328,6 +329,14 @@ class SparkContext(
   // Register a new RDD, returning its RDD ID
   private[spark] def newRddId(): Int = {
     nextRddId.getAndIncrement()
+  }
+
+  /** Moves the next RDD ID so that it will not conflict with the given id. */
+  private[spark] def updateRddId(id: Int) {
+    val delta = id - nextRddId.get + 1
+    if (delta > 0) {
+      nextRddId.addAndGet(delta)
+    }
   }
 }
 

--- a/core/src/main/scala/spark/SparkContext.scala
+++ b/core/src/main/scala/spark/SparkContext.scala
@@ -31,8 +31,8 @@ import org.apache.hadoop.mapreduce.{Job => NewHadoopJob}
 import spark.broadcast._
 
 class SparkContext(
-    master: String,
-    frameworkName: String,
+    private[spark] val master: String,
+    private[spark] val frameworkName: String,
     val sparkHome: String = null,
     val jars: Seq[String] = Nil)
   extends Logging {

--- a/core/src/main/scala/spark/SparkEnv.scala
+++ b/core/src/main/scala/spark/SparkEnv.scala
@@ -1,6 +1,5 @@
 package spark
 
-import akka.actor.Actor._
 import org.jboss.netty.channel.ChannelException
 
 class SparkEnv (

--- a/core/src/main/scala/spark/SparkEnv.scala
+++ b/core/src/main/scala/spark/SparkEnv.scala
@@ -42,25 +42,7 @@ object SparkEnv extends Logging {
 
     val shuffleMgr = new ShuffleManager()
 
-    // Initialize the Akka server on the master
-    if (isMaster) {
-      val host = System.getProperty("spark.master.host")
-      // Repeatedly try to bind to a free port
-      var foundFreePort = false
-      while (!foundFreePort) {
-        try {
-          val remoteServer = remote.start(host, Utils.freePort)
-          System.setProperty("spark.master.akkaPort", remoteServer.address.getPort.toString)
-          logInfo("Akka listening at %s:%d".format(host, remoteServer.address.getPort))
-          foundFreePort = true
-        } catch {
-          case _: ChannelException => {}
-        }
-      }
-    }
-    val akkaDispatcher = new DaemonDispatcher("dispatcher")
-
-    val eventReporter = new EventReporter(isMaster, akkaDispatcher)
+    val eventReporter = new EventReporter(isMaster)
 
     new SparkEnv(cache, serializer, cacheTracker, mapOutputTracker, shuffleFetcher, shuffleMgr, eventReporter)
   }

--- a/core/src/main/scala/spark/Task.scala
+++ b/core/src/main/scala/spark/Task.scala
@@ -3,7 +3,10 @@ package spark
 class TaskContext(val stageId: Int, val splitId: Int, val attemptId: Int) extends Serializable
 
 abstract class Task[T] extends Serializable {
-  def run(id: Int): T
+  def run(id: Int, input: Iterator[_]): T
+  def input: Iterator[_]
+
+  def run(id: Int): T = run(id, input)
   def preferredLocations: Seq[String] = Nil
   def generation: Option[Long] = None
 }

--- a/core/src/main/scala/spark/Task.scala
+++ b/core/src/main/scala/spark/Task.scala
@@ -3,10 +3,7 @@ package spark
 class TaskContext(val stageId: Int, val splitId: Int, val attemptId: Int) extends Serializable
 
 abstract class Task[T] extends Serializable {
-  def run(id: Int, input: Iterator[_]): T
-  def input: Iterator[_]
-
-  def run(id: Int): T = run(id, input)
+  def run(id: Int): T
   def preferredLocations: Seq[String] = Nil
   def generation: Option[Long] = None
 }

--- a/core/src/main/scala/spark/UnionRDD.scala
+++ b/core/src/main/scala/spark/UnionRDD.scala
@@ -45,6 +45,8 @@ class UnionRDD[T: ClassManifest](
   
   override def compute(s: Split): Iterator[T] = s.asInstanceOf[UnionSplit[T]].iterator()
 
+  override def mapDependencies(g: RDD ~> RDD) = new UnionRDD(context, rdds.map(rdd => g(rdd)))
+
   override def preferredLocations(s: Split): Seq[String] =
     s.asInstanceOf[UnionSplit[T]].preferredLocations()
 

--- a/core/src/main/scala/spark/Utils.scala
+++ b/core/src/main/scala/spark/Utils.scala
@@ -184,3 +184,13 @@ object Utils {
     port
   }
 }
+
+/**
+ * Represents a natural transformation from F to G. Such a function maps F[A] to G[A] for all A.
+ * For example, if you give it an F[Int], it will return a G[Int].
+ *
+ * See http://apocalisp.wordpress.com/2010/10/26/type-level-programming-in-scala-part-7-natural-transformation%C2%A0literals/.
+ */
+trait ~>[F[_],G[_]] {
+  def apply[A](a: F[A]): G[A]
+}

--- a/core/src/main/scala/spark/Utils.scala
+++ b/core/src/main/scala/spark/Utils.scala
@@ -2,6 +2,7 @@ package spark
 
 import java.io._
 import java.net.InetAddress
+import java.net.ServerSocket
 import java.util.UUID
 import java.util.concurrent.{Executors, ThreadFactory, ThreadPoolExecutor}
 
@@ -173,5 +174,13 @@ object Utils {
     if (!file.delete()) {
       throw new IOException("Failed to delete: " + file)
     }
+  }
+
+  /** Returns a free port to bind to. */
+  def freePort(): Int = {
+    val server = new ServerSocket(0)
+    val port = server.getLocalPort
+    server.close()
+    port
   }
 }

--- a/core/src/main/scala/spark/Utils.scala
+++ b/core/src/main/scala/spark/Utils.scala
@@ -102,10 +102,10 @@ object Utils {
   // Shuffle the elements of a collection into a random order, returning the
   // result in a new collection. Unlike scala.util.Random.shuffle, this method
   // uses a local random number generator, avoiding inter-thread contention.
-  def randomize[T](seq: TraversableOnce[T]): Seq[T] = {
+  def randomize[T](seq: TraversableOnce[T], seed: Long): Seq[T] = {
     val buf = new ArrayBuffer[T]()
     buf ++= seq
-    val rand = new Random()
+    val rand = new Random(seed)
     for (i <- (buf.size - 1) to 1 by -1) {
       val j = rand.nextInt(i)
       val tmp = buf(j)

--- a/core/src/test/scala/spark/EventLoggingSuite.scala
+++ b/core/src/test/scala/spark/EventLoggingSuite.scala
@@ -1,0 +1,146 @@
+package spark
+
+import java.io.File
+
+import scala.io.Source
+
+import com.google.common.io.Files
+import org.scalatest.FunSuite
+import org.apache.hadoop.io._
+
+import SparkContext._
+
+class EventLoggingSuite extends FunSuite {
+  /**
+   * Enables event logging for the current SparkEnv without setting spark.arthur.logPath. This is
+   * useful for unit tests, where setting a property affects other tests as well.
+   */
+  def initializeEventLogging(eventLog: File, enableArthur: Boolean) {
+    SparkEnv.get.eventReporter.enableArthur = enableArthur
+    SparkEnv.get.eventReporter.init()
+    for (w <- SparkEnv.get.eventReporter.eventLogWriter) {
+      w.setEventLogPath(Some(eventLog.getAbsolutePath))
+    }
+  }
+
+  def makeSparkContextWithoutEventLogging(): SparkContext = {
+    new SparkContext("local", "test")
+  }
+
+  def makeSparkContext(eventLog: File, enableArthur: Boolean = true): SparkContext = {
+    val sc = makeSparkContextWithoutEventLogging()
+    initializeEventLogging(eventLog, enableArthur)
+    sc
+  }
+
+  test("restore ParallelCollection from log") {
+    // Initialize event log
+    val tempDir = Files.createTempDir()
+    val eventLog = new File(tempDir, "eventLog")
+
+    // Make an RDD
+    val sc = makeSparkContext(eventLog)
+    val nums = sc.makeRDD(1 to 4)
+    sc.stop()
+
+    // Read it back from the event log
+    val sc2 = makeSparkContext(eventLog)
+    val r = new EventLogReader(sc2, Some(eventLog.getAbsolutePath))
+    assert(r.rdds.length === 1)
+    assert(r.rdds(0).collect.toList === (1 to 4).toList)
+    sc2.stop()
+  }
+
+  test("interactive event log reading") {
+    // Initialize event log
+    val tempDir = Files.createTempDir()
+    val eventLog = new File(tempDir, "eventLog")
+
+    // Make an RDD
+    val sc = makeSparkContext(eventLog)
+    val nums = sc.makeRDD(1 to 4)
+    for (w <- SparkEnv.get.eventReporter.eventLogWriter)
+      w.flush()
+
+    // Read the RDD back from the event log
+    val sc2 = makeSparkContextWithoutEventLogging()
+    val r = new EventLogReader(sc2, Some(eventLog.getAbsolutePath))
+    assert(r.rdds.length === 1)
+    assert(r.rdds(0).collect.toList === List(1, 2, 3, 4))
+
+    // Make another RDD
+    SparkEnv.set(sc.env)
+    val nums2 = sc.makeRDD(1 to 5)
+    for (w <- SparkEnv.get.eventReporter.eventLogWriter)
+      w.flush()
+
+    // Read it back from the event log
+    SparkEnv.set(sc2.env)
+    r.loadNewEvents()
+    assert(r.rdds.length === 2)
+    assert(r.rdds(1).collect.toList === List(1, 2, 3, 4, 5))
+
+    sc.stop()
+    sc2.stop()
+  }
+
+  test("set nextRddId after restoring") {
+    // Initialize event log
+    val tempDir = Files.createTempDir()
+    val eventLog = new File(tempDir, "eventLog")
+
+    // Make some RDDs
+    val sc = makeSparkContext(eventLog)
+    val nums = sc.makeRDD(1 to 4)
+    val numsMapped = nums.map(x => x + 1)
+    sc.stop()
+
+    // Read them back from the event log
+    val sc2 = makeSparkContext(eventLog)
+    val r = new EventLogReader(sc2, Some(eventLog.getAbsolutePath))
+    assert(r.rdds.length === 2)
+
+    // Make a new RDD and check for ID conflicts
+    val nums2 = sc2.makeRDD(1 to 5)
+    assert(nums2.id != r.rdds(0).id)
+    assert(nums2.id != r.rdds(1).id)
+    sc2.stop()
+  }
+
+  test("task submission logging") {
+    // Initialize event log
+    val tempDir = Files.createTempDir()
+    val eventLog = new File(tempDir, "eventLog")
+
+    // Make an RDD and do some computation to run tasks
+    val sc = makeSparkContext(eventLog)
+    val nums = sc.makeRDD(List(1, 2, 3))
+    val nums2 = nums.map(_ * 2)
+    val nums2List = nums2.collect.toList
+    sc.stop()
+
+    // Verify that tasks were logged
+    val sc2 = makeSparkContext(eventLog)
+    val r = new EventLogReader(sc2, Some(eventLog.getAbsolutePath))
+    val tasks = r.events.collect { case t: TaskSubmission => t }
+    assert(tasks.nonEmpty)
+    sc2.stop()
+  }
+
+  test("disable Arthur") {
+    // Initialize event log
+    val tempDir = Files.createTempDir()
+    val eventLog = new File(tempDir, "eventLog")
+
+    // Make an RDD
+    val sc = makeSparkContext(eventLog, enableArthur = false)
+    val nums = sc.makeRDD(1 to 4)
+    sc.stop()
+
+    // Make sure the event log is empty
+    val sc2 = makeSparkContext(eventLog)
+    val r = new EventLogReader(sc2, Some(eventLog.getAbsolutePath))
+    assert(r.events.isEmpty)
+    sc2.stop()
+  }
+}

--- a/core/src/test/scala/spark/EventLoggingSuite.scala
+++ b/core/src/test/scala/spark/EventLoggingSuite.scala
@@ -171,6 +171,7 @@ class EventLoggingSuite extends FunSuite {
     val sc2 = makeSparkContext(eventLog)
     val r = new EventLogReader(sc2, Some(eventLog.getAbsolutePath))
     r.assert(r.rdds(1).asInstanceOf[RDD[Double]], (x: Double) => !x.isNaN)
+    r.assert(r.rdds(1).asInstanceOf[RDD[Double]], (x: Double) => true) // another assertion on the same RDD
     r.assert(r.rdds(2).asInstanceOf[RDD[Double]], (x: Double, y: Double) => x + y, (x: Double) => x > 0)
     r.rdds(2).foreach(x => {}) // Force assertions to be checked
     sc2.stop()

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -19,7 +19,7 @@ object SparkBuild extends Build {
     organization := "org.spark-project",
     version := "0.4-SNAPSHOT",
     scalaVersion := "2.9.1",
-    scalacOptions := Seq(/*"-deprecation",*/ "-unchecked", "-optimize"), // -deprecation is too noisy due to usage of old Hadoop API, enable it once that's no longer an issue
+    scalacOptions := Seq(/* "-deprecation", */ "-unchecked", "-optimize"), // -deprecation is too noisy due to usage of old Hadoop API, enable it once that's no longer an issue
     unmanagedJars in Compile <<= baseDirectory map { base => (base / "lib" ** "*.jar").classpath },
     retrieveManaged := true,
     transitiveClassifiers in Scope.GlobalScope := Seq("sources"),
@@ -51,7 +51,8 @@ object SparkBuild extends Build {
       "com.ning" % "compress-lzf" % "0.8.4",
       "org.apache.hadoop" % "hadoop-core" % "0.20.2",
       "asm" % "asm-all" % "3.3.1",
-      "com.google.protobuf" % "protobuf-java" % "2.3.0",
+      // Akka 1.2 requires Protobuf 2.4.1; see http://groups.google.com/group/akka-user/msg/80cee7566f0b5741
+      "com.google.protobuf" % "protobuf-java" % "2.4.1",
       "de.javakaffee" % "kryo-serializers" % "0.9",
       "se.scalablesolutions.akka" % "akka-actor" % "1.2",
       "se.scalablesolutions.akka" % "akka-remote" % "1.2",

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -51,11 +51,8 @@ object SparkBuild extends Build {
       "com.ning" % "compress-lzf" % "0.8.4",
       "org.apache.hadoop" % "hadoop-core" % "0.20.2",
       "asm" % "asm-all" % "3.3.1",
-      // Akka 1.2 requires Protobuf 2.4.1; see http://groups.google.com/group/akka-user/msg/80cee7566f0b5741
-      "com.google.protobuf" % "protobuf-java" % "2.4.1",
+      "com.google.protobuf" % "protobuf-java" % "2.3.0",
       "de.javakaffee" % "kryo-serializers" % "0.9",
-      "se.scalablesolutions.akka" % "akka-actor" % "1.2",
-      "se.scalablesolutions.akka" % "akka-remote" % "1.2",
       "org.jboss.netty" % "netty" % "3.2.6.Final",
       "it.unimi.dsi" % "fastutil" % "6.4.2"
     )

--- a/run
+++ b/run
@@ -30,6 +30,10 @@ export SPARK_MEM  # So that the process sees it and can report it to Mesos
 JAVA_OPTS="$SPARK_JAVA_OPTS"
 JAVA_OPTS+=" -Djava.library.path=$SPARK_LIBRARY_PATH:$FWDIR/lib:$FWDIR/src/main/native:$MESOS_LIBRARY_PATH"
 JAVA_OPTS+=" -Xms$SPARK_MEM -Xmx$SPARK_MEM"
+# Enable debugging if appropriate
+if [ "x$SPARK_DEBUG_OPTS" != "x" ] ; then
+  JAVA_OPTS+=" $SPARK_DEBUG_OPTS"
+fi
 # Load extra JAVA_OPTS from conf/java-opts, if it exists
 if [ -e $FWDIR/conf/java-opts ] ; then
   JAVA_OPTS+=" `cat $FWDIR/conf/java-opts`"


### PR DESCRIPTION
Arthur provides replay debugging for deterministic errors in Spark programs. Execution recording is turned off by default unless the user sets `spark.arthur.logPath`. The user can then load the log and replay the program using `EventLogReader`.
