### PR TITLE
Report entry dropping in BoundedMemoryCache

### DIFF
--- a/core/src/main/scala/spark/BoundedMemoryCache.scala
+++ b/core/src/main/scala/spark/BoundedMemoryCache.scala
@@ -70,5 +70,6 @@ class BoundedMemoryCache extends Cache with Logging {
 
   protected def dropEntry(key: Any, entry: Entry) {
     logInfo("Dropping key %s of size %d to make space".format(key, entry.size))
+    SparkEnv.get.cacheTracker.dropEntry(key)
   }
 }

--- a/core/src/main/scala/spark/CacheTracker.scala
+++ b/core/src/main/scala/spark/CacheTracker.scala
@@ -143,6 +143,17 @@ class CacheTracker(isMaster: Boolean, theCache: Cache) extends Logging {
     }
   }
 
+  // Reports that an entry has been dropped from the cache
+  def dropEntry(key: Any) {
+    key match {
+      case (keySpaceId: Long, (rddId: Int, partition: Int)) =>
+        val host = System.getProperty("spark.hostname", Utils.localHostName)
+        trackerActor !! DroppedFromCache(rddId, partition, host)
+      case _ =>
+        logWarning("Unknown key format: %s".format(key))
+    }
+  }
+
   def stop() {
     trackerActor !? StopCacheTracker
     registeredRddIds.clear()


### PR DESCRIPTION
When BoundedMemoryCache dropped a key, it previously only logged the event to the local log on the slave. Now it reports that fact to the master as well.

This makes it possible to write tools that process the driver output and visualize cache usage across the cluster. It also will make it easier for Arthur to track this information.
