### PR TITLE
End task instead of just exiting in LocalScheduler for tasks that throw exceptions

### DIFF
--- a/core/src/main/scala/spark/LocalScheduler.scala
+++ b/core/src/main/scala/spark/LocalScheduler.scala
@@ -58,7 +58,8 @@ private class LocalScheduler(threads: Int, maxFailures: Int) extends DAGSchedule
               submitTask(task, idInJob)
             } else {
               // TODO: Do something nicer here to return all the way to the user
-              System.exit(1)
+              //System.exit(1)
+              taskEnded(task, new ExceptionFailure(t), null, null)
             }
           }
         }

--- a/core/src/main/scala/spark/LocalScheduler.scala
+++ b/core/src/main/scala/spark/LocalScheduler.scala
@@ -58,7 +58,6 @@ private class LocalScheduler(threads: Int, maxFailures: Int) extends DAGSchedule
               submitTask(task, idInJob)
             } else {
               // TODO: Do something nicer here to return all the way to the user
-              //System.exit(1)
               taskEnded(task, new ExceptionFailure(t), null, null)
             }
           }


### PR DESCRIPTION
(our Shark testing suite driver was hanging on tests for which an exception was thrown on a worker)
