### PR TITLE
Force serialize/deserialize task results in local execution mode.

### DIFF
--- a/core/src/test/scala/spark/FailureSuite.scala
+++ b/core/src/test/scala/spark/FailureSuite.scala
@@ -65,5 +65,21 @@ class FailureSuite extends FunSuite {
     FailureSuiteState.clear()
   }
 
+  test("failure because task results are not serializable") {
+    val sc = new SparkContext("local[1,1]", "test")
+    val results = sc.makeRDD(1 to 3).map(x => new NonSerializable)
+
+    val thrown = intercept[spark.SparkException] {
+      results.collect()
+    }
+    assert(thrown.getClass === classOf[spark.SparkException])
+    assert(thrown.getMessage.contains("NotSerializableException"))
+
+    sc.stop()
+    FailureSuiteState.clear()
+  }
+
   // TODO: Need to add tests with shuffle fetch failures.
 }
+
+


### PR DESCRIPTION
In Shark, we were caught by surprise when we tested map join implementation on a cluster that it'd failed because of serialization. This commit forces a serialization/deserialization of task result data even for local modes to avoid such surprises.
