### PR TITLE
add Accumulatable, add corresponding docs & tests for accumulators

### DIFF
--- a/core/src/main/scala/spark/Accumulators.scala
+++ b/core/src/main/scala/spark/Accumulators.scala
@@ -35,9 +35,40 @@ class Accumulator[T] (
   override def toString = value_.toString
 }
 
+class Accumulatable[T,Y](
+    @transient initialValue: T,
+    param: AccumulatableParam[T,Y]) extends Accumulator[T](initialValue, param) {
+  /**
+   * add more data to the current value of the this accumulator, via
+   * AccumulatableParam.addToAccum
+   * @param term
+   */
+  def +:= (term: Y) {value_ = param.addToAccum(value_, term)}
+}
+
+/**
+ * A datatype that can be accumulated, ie. has a commutative & associative +
+ * @tparam T
+ */
 trait AccumulatorParam[T] extends Serializable {
   def addInPlace(t1: T, t2: T): T
   def zero(initialValue: T): T
+}
+
+/**
+ * A datatype that can be accumulated.  Slightly extends [[spark.AccumulatorParam]] to allow you to
+ * combine a different data type with value so far
+ * @tparam T the full accumulated data
+ * @tparam Y partial data that can be added in
+ */
+trait AccumulatableParam[T,Y] extends AccumulatorParam[T] {
+  /**
+   * Add additional data to the accumulator value.
+   * @param t1 the current value of the accumulator
+   * @param t2 the data to be added to the accumulator
+   * @return the new value of the accumulator
+   */
+  def addToAccum(t1: T, t2: Y) : T
 }
 
 // TODO: The multi-thread support in accumulators is kind of lame; check

--- a/core/src/main/scala/spark/Accumulators.scala
+++ b/core/src/main/scala/spark/Accumulators.scala
@@ -19,7 +19,7 @@ class Accumulable[T,R] (
 
   /**
    * add more data to this accumulator / accumulable
-   * @param term
+   * @param term the data to add
    */
   def += (term: R) { value_ = param.addAccumulator(value_, term) }
 
@@ -27,7 +27,7 @@ class Accumulable[T,R] (
    * merge two accumulable objects together
    * <p>
    * Normally, a user will not want to use this version, but will instead call `+=`.
-   * @param term
+   * @param term the other Accumulable that will get merged with this
    */
   def ++= (term: T) { value_ = param.addInPlace(value_, term)}
   def value = this.value_
@@ -64,33 +64,33 @@ trait AccumulatorParam[T] extends AccumulableParam[T,T] {
 
 /**
  * A datatype that can be accumulated, ie. has a commutative & associative +.
- * <p>
+ * 
  * You must define how to add data, and how to merge two of these together.  For some datatypes, these might be
  * the same operation (eg., a counter).  In that case, you might want to use [[spark.AccumulatorParam]].  They won't
  * always be the same, though -- eg., imagine you are accumulating a set.  You will add items to the set, and you
  * will union two sets together.
  *
- * @tparam T the full accumulated data
- * @tparam R partial data that can be added in
+ * @tparam R the full accumulated data
+ * @tparam T partial data that can be added in
  */
-trait AccumulableParam[T,R] extends Serializable {
+trait AccumulableParam[R,T] extends Serializable {
   /**
    * Add additional data to the accumulator value.
    * @param t1 the current value of the accumulator
    * @param t2 the data to be added to the accumulator
    * @return the new value of the accumulator
    */
-  def addAccumulator(t1: T, t2: R) : T
+  def addAccumulator(t1: R, t2: T) : R
 
   /**
    * merge two accumulated values together
-   * @param t1
-   * @param t2
-   * @return
+   * @param t1 one set of accumulated data
+   * @param t2 another set of accumulated data
+   * @return both data sets merged together
    */
-  def addInPlace(t1: T, t2: T): T
+  def addInPlace(t1: R, t2: R): R
 
-  def zero(initialValue: T): T
+  def zero(initialValue: R): R
 }
 
 // TODO: The multi-thread support in accumulators is kind of lame; check

--- a/core/src/main/scala/spark/Accumulators.scala
+++ b/core/src/main/scala/spark/Accumulators.scala
@@ -21,7 +21,7 @@ class Accumulable[T,R] (
    * add more data to this accumulator / accumulable
    * @param term
    */
-  def += (term: R) { value_ = param.addToAccum(value_, term) }
+  def += (term: R) { value_ = param.addAccumulator(value_, term) }
 
   /**
    * merge two accumulable objects together
@@ -57,7 +57,7 @@ class Accumulator[T](
  * @tparam T
  */
 trait AccumulatorParam[T] extends AccumulableParam[T,T] {
-  def addToAccum(t1: T, t2: T) : T = {
+  def addAccumulator(t1: T, t2: T) : T = {
     addInPlace(t1, t2)
   }
 }
@@ -80,7 +80,7 @@ trait AccumulableParam[T,R] extends Serializable {
    * @param t2 the data to be added to the accumulator
    * @return the new value of the accumulator
    */
-  def addToAccum(t1: T, t2: R) : T
+  def addAccumulator(t1: T, t2: R) : T
 
   /**
    * merge two accumulated values together

--- a/core/src/main/scala/spark/Accumulators.scala
+++ b/core/src/main/scala/spark/Accumulators.scala
@@ -4,9 +4,9 @@ import java.io._
 
 import scala.collection.mutable.Map
 
-class Accumulator[T] (
+class Accumulable[T,R] (
     @transient initialValue: T,
-    param: AccumulatorParam[T])
+    param: AccumulableParam[T,R])
   extends Serializable {
   
   val id = Accumulators.newId
@@ -17,7 +17,19 @@ class Accumulator[T] (
 
   Accumulators.register(this, true)
 
-  def += (term: T) { value_ = param.addInPlace(value_, term) }
+  /**
+   * add more data to this accumulator / accumulable
+   * @param term
+   */
+  def += (term: R) { value_ = param.addToAccum(value_, term) }
+
+  /**
+   * merge two accumulable objects together
+   * <p>
+   * Normally, a user will not want to use this version, but will instead call `+=`.
+   * @param term
+   */
+  def ++= (term: T) { value_ = param.addInPlace(value_, term)}
   def value = this.value_
   def value_= (t: T) {
     if (!deserialized) value_ = t
@@ -35,48 +47,58 @@ class Accumulator[T] (
   override def toString = value_.toString
 }
 
-class Accumulatable[T,Y](
+class Accumulator[T](
     @transient initialValue: T,
-    param: AccumulatableParam[T,Y]) extends Accumulator[T](initialValue, param) {
-  /**
-   * add more data to the current value of the this accumulator, via
-   * AccumulatableParam.addToAccum
-   * @param term added to the current value of the accumulator
-   */
-  def +:= (term: Y) {value_ = param.addToAccum(value_, term)}
-}
+    param: AccumulatorParam[T]) extends Accumulable[T,T](initialValue, param)
 
 /**
- * A datatype that can be accumulated, ie. has a commutative & associative +
+ * A simpler version of [[spark.AccumulableParam]] where the only datatype you can add in is the same type
+ * as the accumulated value
  * @tparam T
  */
-trait AccumulatorParam[T] extends Serializable {
-  def addInPlace(t1: T, t2: T): T
-  def zero(initialValue: T): T
+trait AccumulatorParam[T] extends AccumulableParam[T,T] {
+  def addToAccum(t1: T, t2: T) : T = {
+    addInPlace(t1, t2)
+  }
 }
 
 /**
- * A datatype that can be accumulated.  Slightly extends [[spark.AccumulatorParam]] to allow you to
- * combine a different data type with value so far
+ * A datatype that can be accumulated, ie. has a commutative & associative +.
+ * <p>
+ * You must define how to add data, and how to merge two of these together.  For some datatypes, these might be
+ * the same operation (eg., a counter).  In that case, you might want to use [[spark.AccumulatorParam]].  They won't
+ * always be the same, though -- eg., imagine you are accumulating a set.  You will add items to the set, and you
+ * will union two sets together.
+ *
  * @tparam T the full accumulated data
- * @tparam Y partial data that can be added in
+ * @tparam R partial data that can be added in
  */
-trait AccumulatableParam[T,Y] extends AccumulatorParam[T] {
+trait AccumulableParam[T,R] extends Serializable {
   /**
    * Add additional data to the accumulator value.
    * @param t1 the current value of the accumulator
    * @param t2 the data to be added to the accumulator
    * @return the new value of the accumulator
    */
-  def addToAccum(t1: T, t2: Y) : T
+  def addToAccum(t1: T, t2: R) : T
+
+  /**
+   * merge two accumulated values together
+   * @param t1
+   * @param t2
+   * @return
+   */
+  def addInPlace(t1: T, t2: T): T
+
+  def zero(initialValue: T): T
 }
 
 // TODO: The multi-thread support in accumulators is kind of lame; check
 // if there's a more intuitive way of doing it right
 private object Accumulators {
   // TODO: Use soft references? => need to make readObject work properly then
-  val originals = Map[Long, Accumulator[_]]()
-  val localAccums = Map[Thread, Map[Long, Accumulator[_]]]()
+  val originals = Map[Long, Accumulable[_,_]]()
+  val localAccums = Map[Thread, Map[Long, Accumulable[_,_]]]()
   var lastId: Long = 0
   
   def newId: Long = synchronized {
@@ -84,7 +106,7 @@ private object Accumulators {
     return lastId
   }
 
-  def register(a: Accumulator[_], original: Boolean): Unit = synchronized {
+  def register(a: Accumulable[_,_], original: Boolean): Unit = synchronized {
     if (original) {
       originals(a.id) = a
     } else {
@@ -111,7 +133,7 @@ private object Accumulators {
   def add(values: Map[Long, Any]): Unit = synchronized {
     for ((id, value) <- values) {
       if (originals.contains(id)) {
-        originals(id).asInstanceOf[Accumulator[Any]] += value
+        originals(id).asInstanceOf[Accumulable[Any, Any]] ++= value
       }
     }
   }

--- a/core/src/main/scala/spark/Accumulators.scala
+++ b/core/src/main/scala/spark/Accumulators.scala
@@ -41,7 +41,7 @@ class Accumulatable[T,Y](
   /**
    * add more data to the current value of the this accumulator, via
    * AccumulatableParam.addToAccum
-   * @param term
+   * @param term added to the current value of the accumulator
    */
   def +:= (term: Y) {value_ = param.addToAccum(value_, term)}
 }

--- a/core/src/main/scala/spark/Accumulators.scala
+++ b/core/src/main/scala/spark/Accumulators.scala
@@ -25,7 +25,7 @@ class Accumulable[T,R] (
 
   /**
    * merge two accumulable objects together
-   * <p>
+   * 
    * Normally, a user will not want to use this version, but will instead call `+=`.
    * @param term the other Accumulable that will get merged with this
    */
@@ -64,7 +64,7 @@ trait AccumulatorParam[T] extends AccumulableParam[T,T] {
 
 /**
  * A datatype that can be accumulated, ie. has a commutative & associative +.
- * 
+ *
  * You must define how to add data, and how to merge two of these together.  For some datatypes, these might be
  * the same operation (eg., a counter).  In that case, you might want to use [[spark.AccumulatorParam]].  They won't
  * always be the same, though -- eg., imagine you are accumulating a set.  You will add items to the set, and you

--- a/core/src/main/scala/spark/SparkContext.scala
+++ b/core/src/main/scala/spark/SparkContext.scala
@@ -249,15 +249,15 @@ class SparkContext(
     new Accumulator(initialValue, param)
 
   /**
-   * create an accumulatable shared variable, with a `+:=` method
+   * create an accumulatable shared variable, with a `+=` method
    * @param initialValue
    * @param param
    * @tparam T accumulator type
-   * @tparam Y type that can be added to the accumulator
+   * @tparam R type that can be added to the accumulator
    * @return
    */
-  def accumulatable[T,Y](initialValue: T)(implicit param: AccumulatableParam[T,Y]) =
-    new Accumulatable(initialValue, param)
+  def accumulable[T,R](initialValue: T)(implicit param: AccumulableParam[T,R]) =
+    new Accumulable(initialValue, param)
 
 
   // Keep around a weak hash map of values to Cached versions?

--- a/core/src/main/scala/spark/SparkContext.scala
+++ b/core/src/main/scala/spark/SparkContext.scala
@@ -250,11 +250,8 @@ class SparkContext(
 
   /**
    * create an accumulatable shared variable, with a `+=` method
-   * @param initialValue
-   * @param param
    * @tparam T accumulator type
    * @tparam R type that can be added to the accumulator
-   * @return
    */
   def accumulable[T,R](initialValue: T)(implicit param: AccumulableParam[T,R]) =
     new Accumulable(initialValue, param)

--- a/core/src/main/scala/spark/SparkContext.scala
+++ b/core/src/main/scala/spark/SparkContext.scala
@@ -248,6 +248,18 @@ class SparkContext(
   def accumulator[T](initialValue: T)(implicit param: AccumulatorParam[T]) =
     new Accumulator(initialValue, param)
 
+  /**
+   * create an accumulatable shared variable, with a `+:=` method
+   * @param initialValue
+   * @param param
+   * @tparam T accumulator type
+   * @tparam Y type that can be added to the accumulator
+   * @return
+   */
+  def accumulatable[T,Y](initialValue: T)(implicit param: AccumulatableParam[T,Y]) =
+    new Accumulatable(initialValue, param)
+
+
   // Keep around a weak hash map of values to Cached versions?
   def broadcast[T](value: T) = Broadcast.getBroadcastFactory.newBroadcast[T] (value, isLocal)
 

--- a/core/src/main/scala/spark/util/Vector.scala
+++ b/core/src/main/scala/spark/util/Vector.scala
@@ -29,7 +29,37 @@ class Vector(val elements: Array[Double]) extends Serializable {
     return ans
   }
 
-  def * (scale: Double): Vector = Vector(length, i => this(i) * scale)
+  /**
+   * return (this + plus) dot other, but without creating any intermediate storage
+   * @param plus
+   * @param other
+   * @return
+   */
+  def plusDot(plus: Vector, other: Vector): Double = {
+    if (length != other.length)
+      throw new IllegalArgumentException("Vectors of different length")
+    if (length != plus.length)
+      throw new IllegalArgumentException("Vectors of different length")
+    var ans = 0.0
+    var i = 0
+    while (i < length) {
+      ans += (this(i) + plus(i)) * other(i)
+      i += 1
+    }
+    return ans
+  }
+
+  def +=(other: Vector) {
+    if (length != other.length)
+      throw new IllegalArgumentException("Vectors of different length")
+    var ans = 0.0
+    var i = 0
+    while (i < length) {
+      elements(i) += other(i)
+      i += 1
+    }
+  }
+
   def * (scale: Double): Vector = Vector(length, i => this(i) * scale)
 
   def / (d: Double): Vector = this * (1 / d)

--- a/core/src/main/scala/spark/util/Vector.scala
+++ b/core/src/main/scala/spark/util/Vector.scala
@@ -1,8 +1,8 @@
-package spark.examples
+package spark.util
 
 class Vector(val elements: Array[Double]) extends Serializable {
   def length = elements.length
-  
+
   def apply(index: Int) = elements(index)
 
   def + (other: Vector): Vector = {
@@ -30,11 +30,12 @@ class Vector(val elements: Array[Double]) extends Serializable {
   }
 
   def * (scale: Double): Vector = Vector(length, i => this(i) * scale)
+  def * (scale: Double): Vector = Vector(length, i => this(i) * scale)
 
   def / (d: Double): Vector = this * (1 / d)
 
   def unary_- = this * -1
-  
+
   def sum = elements.reduceLeft(_ + _)
 
   def squaredDist(other: Vector): Double = {
@@ -76,6 +77,8 @@ object Vector {
 
   implicit object VectorAccumParam extends spark.AccumulatorParam[Vector] {
     def addInPlace(t1: Vector, t2: Vector) = t1 + t2
+
     def zero(initialValue: Vector) = Vector.zeros(initialValue.length)
   }
+
 }

--- a/core/src/test/scala/spark/AccumulatorSuite.scala
+++ b/core/src/test/scala/spark/AccumulatorSuite.scala
@@ -64,8 +64,7 @@ class AccumulatorSuite extends FunSuite with ShouldMatchers {
 
 
   test ("value readable in tasks") {
-    import Vector.VectorAccumParam._
-    import Vector._
+    import spark.util.Vector
     //stochastic gradient descent with weights stored in accumulator -- should be able to read value as we go
 
     //really easy data
@@ -121,113 +120,4 @@ class AccumulatorSuite extends FunSuite with ShouldMatchers {
     }
   }
 
-}
-
-
-
-//ugly copy and paste from examples ...
-class Vector(val elements: Array[Double]) extends Serializable {
-  def length = elements.length
-
-  def apply(index: Int) = elements(index)
-
-  def + (other: Vector): Vector = {
-    if (length != other.length)
-      throw new IllegalArgumentException("Vectors of different length")
-    return Vector(length, i => this(i) + other(i))
-  }
-
-  def - (other: Vector): Vector = {
-    if (length != other.length)
-      throw new IllegalArgumentException("Vectors of different length")
-    return Vector(length, i => this(i) - other(i))
-  }
-
-  def dot(other: Vector): Double = {
-    if (length != other.length)
-      throw new IllegalArgumentException("Vectors of different length")
-    var ans = 0.0
-    var i = 0
-    while (i < length) {
-      ans += this(i) * other(i)
-      i += 1
-    }
-    return ans
-  }
-
-  def plusDot(plus: Vector, other: Vector): Double = {
-    if (length != other.length)
-      throw new IllegalArgumentException("Vectors of different length")
-    if (length != plus.length)
-      throw new IllegalArgumentException("Vectors of different length")
-    var ans = 0.0
-    var i = 0
-    while (i < length) {
-      ans += (this(i) + plus(i)) * other(i)
-      i += 1
-    }
-    return ans
-  }
-
-  def += (other: Vector) {
-    if (length != other.length)
-      throw new IllegalArgumentException("Vectors of different length")
-    var ans = 0.0
-    var i = 0
-    while (i < length) {
-      elements(i) += other(i)
-      i += 1
-    }
-  }
-
-
-  def * (scale: Double): Vector = Vector(length, i => this(i) * scale)
-
-  def / (d: Double): Vector = this * (1 / d)
-
-  def unary_- = this * -1
-
-  def sum = elements.reduceLeft(_ + _)
-
-  def squaredDist(other: Vector): Double = {
-    var ans = 0.0
-    var i = 0
-    while (i < length) {
-      ans += (this(i) - other(i)) * (this(i) - other(i))
-      i += 1
-    }
-    return ans
-  }
-
-  def dist(other: Vector): Double = math.sqrt(squaredDist(other))
-
-  override def toString = elements.mkString("(", ", ", ")")
-}
-
-object Vector {
-  def apply(elements: Array[Double]) = new Vector(elements)
-
-  def apply(elements: Double*) = new Vector(elements.toArray)
-
-  def apply(length: Int, initializer: Int => Double): Vector = {
-    val elements = new Array[Double](length)
-    for (i <- 0 until length)
-      elements(i) = initializer(i)
-    return new Vector(elements)
-  }
-
-  def zeros(length: Int) = new Vector(new Array[Double](length))
-
-  def ones(length: Int) = Vector(length, _ => 1)
-
-  class Multiplier(num: Double) {
-    def * (vec: Vector) = vec * num
-  }
-
-  implicit def doubleToMultiplier(num: Double) = new Multiplier(num)
-
-  implicit object VectorAccumParam extends spark.AccumulatorParam[Vector] {
-    def addInPlace(t1: Vector, t2: Vector) = t1 + t2
-    def zero(initialValue: Vector) = Vector.zeros(initialValue.length)
-  }
 }

--- a/core/src/test/scala/spark/AccumulatorSuite.scala
+++ b/core/src/test/scala/spark/AccumulatorSuite.scala
@@ -53,7 +53,7 @@ class AccumulatorSuite extends FunSuite with ShouldMatchers {
       t1 ++= t2
       t1
     }
-    def addToAccum(t1: mutable.Set[Any], t2: Any) : mutable.Set[Any] = {
+    def addAccumulator(t1: mutable.Set[Any], t2: Any) : mutable.Set[Any] = {
       t1 += t2
       t1
     }

--- a/core/src/test/scala/spark/AccumulatorSuite.scala
+++ b/core/src/test/scala/spark/AccumulatorSuite.scala
@@ -1,0 +1,233 @@
+package spark
+
+import org.scalatest.FunSuite
+import org.scalatest.matchers.ShouldMatchers
+import collection.mutable
+import java.util.Random
+import scala.math.exp
+import scala.math.signum
+import spark.SparkContext._
+
+class AccumulatorSuite extends FunSuite with ShouldMatchers {
+
+  test ("basic accumulation"){
+    val sc = new SparkContext("local", "test")
+    val acc : Accumulator[Int] = sc.accumulator(0)
+
+    val d = sc.parallelize(1 to 20)
+    d.foreach{x => acc += x}
+    acc.value should be (210)
+    sc.stop()
+  }
+
+  test ("value not assignable from tasks") {
+    val sc = new SparkContext("local", "test")
+    val acc : Accumulator[Int] = sc.accumulator(0)
+
+    val d = sc.parallelize(1 to 20)
+    evaluating {d.foreach{x => acc.value = x}} should produce [Exception]
+    sc.stop()
+  }
+
+  test ("add value to collection accumulators") {
+    import SetAccum._
+    val maxI = 1000
+    for (nThreads <- List(1, 10)) { //test single & multi-threaded
+      val sc = new SparkContext("local[" + nThreads + "]", "test")
+      val acc: Accumulatable[mutable.Set[Any], Any] = sc.accumulatable(new mutable.HashSet[Any]())
+      val d = sc.parallelize(1 to maxI)
+      d.foreach {
+        x => acc +:= x //note the use of +:= here
+      }
+      val v = acc.value.asInstanceOf[mutable.Set[Int]]
+      for (i <- 1 to maxI) {
+        v should contain(i)
+      }
+      sc.stop()
+    }
+  }
+
+
+  implicit object SetAccum extends AccumulatableParam[mutable.Set[Any], Any] {
+    def addInPlace(t1: mutable.Set[Any], t2: mutable.Set[Any]) : mutable.Set[Any] = {
+      t1 ++= t2
+      t1
+    }
+    def addToAccum(t1: mutable.Set[Any], t2: Any) : mutable.Set[Any] = {
+      t1 += t2
+      t1
+    }
+    def zero(t: mutable.Set[Any]) : mutable.Set[Any] = {
+      new mutable.HashSet[Any]()
+    }
+  }
+
+
+  test ("value readable in tasks") {
+    import Vector.VectorAccumParam._
+    import Vector._
+    //stochastic gradient descent with weights stored in accumulator -- should be able to read value as we go
+
+    //really easy data
+    val N = 10000  // Number of data points
+    val D = 10   // Numer of dimensions
+    val R = 0.7  // Scaling factor
+    val ITERATIONS = 5
+    val rand = new Random(42)
+
+    case class DataPoint(x: Vector, y: Double)
+
+    def generateData = {
+      def generatePoint(i: Int) = {
+        val y = if(i % 2 == 0) -1 else 1
+        val goodX = Vector(D, _ => 0.0001 * rand.nextGaussian() + y)
+        val noiseX = Vector(D, _ => rand.nextGaussian())
+        val x = Vector((goodX.elements.toSeq ++ noiseX.elements.toSeq): _*)
+        DataPoint(x, y)
+      }
+      Array.tabulate(N)(generatePoint)
+    }
+
+    val data = generateData
+    for (nThreads <- List(1, 10)) {
+      //test single & multi-threaded
+      val sc = new SparkContext("local[" + nThreads + "]", "test")
+      val weights = Vector.zeros(2*D)
+      val weightDelta = sc.accumulator(Vector.zeros(2 * D))
+      for (itr <- 1 to ITERATIONS) {
+        val eta = 0.1 / itr
+        val badErrs = sc.accumulator(0)
+        sc.parallelize(data).foreach {
+          p => {
+            //XXX Note the call to .value here.  That is required for this to be an online gradient descent
+            // instead of a batch version.  Should it change to .localValue, and should .value throw an error
+            // if you try to do this??
+            val prod = weightDelta.value.plusDot(weights, p.x)
+            val trueClassProb = (1 / (1 + exp(-p.y * prod)))  // works b/c p(-z) = 1 - p(z) (where p is the logistic function)
+            val update = p.x * trueClassProb * p.y * eta
+            //we could also include a momentum term here if our weightDelta accumulator saved a momentum
+            weightDelta.value += update
+            if (trueClassProb <= 0.95)
+              badErrs += 1
+          }
+        }
+        println("Iteration " + itr + " had badErrs = " + badErrs.value)
+        weights += weightDelta.value
+        println(weights)
+        //TODO I should check the number of bad errors here, but for some reason spark tries to serialize the assertion ...
+        val assertVal = badErrs.value
+        assert (assertVal < 100)
+      }
+    }
+  }
+
+}
+
+
+
+//ugly copy and paste from examples ...
+class Vector(val elements: Array[Double]) extends Serializable {
+  def length = elements.length
+
+  def apply(index: Int) = elements(index)
+
+  def + (other: Vector): Vector = {
+    if (length != other.length)
+      throw new IllegalArgumentException("Vectors of different length")
+    return Vector(length, i => this(i) + other(i))
+  }
+
+  def - (other: Vector): Vector = {
+    if (length != other.length)
+      throw new IllegalArgumentException("Vectors of different length")
+    return Vector(length, i => this(i) - other(i))
+  }
+
+  def dot(other: Vector): Double = {
+    if (length != other.length)
+      throw new IllegalArgumentException("Vectors of different length")
+    var ans = 0.0
+    var i = 0
+    while (i < length) {
+      ans += this(i) * other(i)
+      i += 1
+    }
+    return ans
+  }
+
+  def plusDot(plus: Vector, other: Vector): Double = {
+    if (length != other.length)
+      throw new IllegalArgumentException("Vectors of different length")
+    if (length != plus.length)
+      throw new IllegalArgumentException("Vectors of different length")
+    var ans = 0.0
+    var i = 0
+    while (i < length) {
+      ans += (this(i) + plus(i)) * other(i)
+      i += 1
+    }
+    return ans
+  }
+
+  def += (other: Vector) {
+    if (length != other.length)
+      throw new IllegalArgumentException("Vectors of different length")
+    var ans = 0.0
+    var i = 0
+    while (i < length) {
+      elements(i) += other(i)
+      i += 1
+    }
+  }
+
+
+  def * (scale: Double): Vector = Vector(length, i => this(i) * scale)
+
+  def / (d: Double): Vector = this * (1 / d)
+
+  def unary_- = this * -1
+
+  def sum = elements.reduceLeft(_ + _)
+
+  def squaredDist(other: Vector): Double = {
+    var ans = 0.0
+    var i = 0
+    while (i < length) {
+      ans += (this(i) - other(i)) * (this(i) - other(i))
+      i += 1
+    }
+    return ans
+  }
+
+  def dist(other: Vector): Double = math.sqrt(squaredDist(other))
+
+  override def toString = elements.mkString("(", ", ", ")")
+}
+
+object Vector {
+  def apply(elements: Array[Double]) = new Vector(elements)
+
+  def apply(elements: Double*) = new Vector(elements.toArray)
+
+  def apply(length: Int, initializer: Int => Double): Vector = {
+    val elements = new Array[Double](length)
+    for (i <- 0 until length)
+      elements(i) = initializer(i)
+    return new Vector(elements)
+  }
+
+  def zeros(length: Int) = new Vector(new Array[Double](length))
+
+  def ones(length: Int) = Vector(length, _ => 1)
+
+  class Multiplier(num: Double) {
+    def * (vec: Vector) = vec * num
+  }
+
+  implicit def doubleToMultiplier(num: Double) = new Multiplier(num)
+
+  implicit object VectorAccumParam extends spark.AccumulatorParam[Vector] {
+    def addInPlace(t1: Vector, t2: Vector) = t1 + t2
+    def zero(initialValue: Vector) = Vector.zeros(initialValue.length)
+  }
+}

--- a/core/src/test/scala/spark/AccumulatorSuite.scala
+++ b/core/src/test/scala/spark/AccumulatorSuite.scala
@@ -34,10 +34,10 @@ class AccumulatorSuite extends FunSuite with ShouldMatchers {
     val maxI = 1000
     for (nThreads <- List(1, 10)) { //test single & multi-threaded
       val sc = new SparkContext("local[" + nThreads + "]", "test")
-      val acc: Accumulatable[mutable.Set[Any], Any] = sc.accumulatable(new mutable.HashSet[Any]())
+      val acc: Accumulable[mutable.Set[Any], Any] = sc.accumulable(new mutable.HashSet[Any]())
       val d = sc.parallelize(1 to maxI)
       d.foreach {
-        x => acc +:= x //note the use of +:= here
+        x => acc += x
       }
       val v = acc.value.asInstanceOf[mutable.Set[Int]]
       for (i <- 1 to maxI) {
@@ -48,7 +48,7 @@ class AccumulatorSuite extends FunSuite with ShouldMatchers {
   }
 
 
-  implicit object SetAccum extends AccumulatableParam[mutable.Set[Any], Any] {
+  implicit object SetAccum extends AccumulableParam[mutable.Set[Any], Any] {
     def addInPlace(t1: mutable.Set[Any], t2: mutable.Set[Any]) : mutable.Set[Any] = {
       t1 ++= t2
       t1
@@ -115,8 +115,8 @@ class AccumulatorSuite extends FunSuite with ShouldMatchers {
         weights += weightDelta.value
         println(weights)
         //TODO I should check the number of bad errors here, but for some reason spark tries to serialize the assertion ...
-        val assertVal = badErrs.value
-        assert (assertVal < 100)
+//        val assertVal = badErrs.value
+//        assert (assertVal < 100)
       }
     }
   }

--- a/core/src/test/scala/spark/AccumulatorSuite.scala
+++ b/core/src/test/scala/spark/AccumulatorSuite.scala
@@ -63,60 +63,19 @@ class AccumulatorSuite extends FunSuite with ShouldMatchers {
   }
 
 
-  test ("value readable in tasks") {
-    import spark.util.Vector
-    //stochastic gradient descent with weights stored in accumulator -- should be able to read value as we go
-
-    //really easy data
-    val N = 10000  // Number of data points
-    val D = 10   // Numer of dimensions
-    val R = 0.7  // Scaling factor
-    val ITERATIONS = 5
-    val rand = new Random(42)
-
-    case class DataPoint(x: Vector, y: Double)
-
-    def generateData = {
-      def generatePoint(i: Int) = {
-        val y = if(i % 2 == 0) -1 else 1
-        val goodX = Vector(D, _ => 0.0001 * rand.nextGaussian() + y)
-        val noiseX = Vector(D, _ => rand.nextGaussian())
-        val x = Vector((goodX.elements.toSeq ++ noiseX.elements.toSeq): _*)
-        DataPoint(x, y)
-      }
-      Array.tabulate(N)(generatePoint)
-    }
-
-    val data = generateData
-    for (nThreads <- List(1, 10)) {
-      //test single & multi-threaded
-      val sc = new SparkContext("local[" + nThreads + "]", "test")
-      val weights = Vector.zeros(2*D)
-      val weightDelta = sc.accumulator(Vector.zeros(2 * D))
-      for (itr <- 1 to ITERATIONS) {
-        val eta = 0.1 / itr
-        val badErrs = sc.accumulator(0)
-        sc.parallelize(data).foreach {
-          p => {
-            //XXX Note the call to .value here.  That is required for this to be an online gradient descent
-            // instead of a batch version.  Should it change to .localValue, and should .value throw an error
-            // if you try to do this??
-            val prod = weightDelta.value.plusDot(weights, p.x)
-            val trueClassProb = (1 / (1 + exp(-p.y * prod)))  // works b/c p(-z) = 1 - p(z) (where p is the logistic function)
-            val update = p.x * trueClassProb * p.y * eta
-            //we could also include a momentum term here if our weightDelta accumulator saved a momentum
-            weightDelta.value += update
-            if (trueClassProb <= 0.95)
-              badErrs += 1
-          }
+  test ("value not readable in tasks") {
+    import SetAccum._
+    val maxI = 1000
+    for (nThreads <- List(1, 10)) { //test single & multi-threaded
+    val sc = new SparkContext("local[" + nThreads + "]", "test")
+      val acc: Accumulable[mutable.Set[Any], Any] = sc.accumulable(new mutable.HashSet[Any]())
+      val d = sc.parallelize(1 to maxI)
+      val thrown = evaluating {
+        d.foreach {
+          x => acc.value += x
         }
-        println("Iteration " + itr + " had badErrs = " + badErrs.value)
-        weights += weightDelta.value
-        println(weights)
-        //TODO I should check the number of bad errors here, but for some reason spark tries to serialize the assertion ...
-//        val assertVal = badErrs.value
-//        assert (assertVal < 100)
-      }
+      } should produce [SparkException]
+      println(thrown)
     }
   }
 

--- a/examples/src/main/scala/spark/examples/LocalFileLR.scala
+++ b/examples/src/main/scala/spark/examples/LocalFileLR.scala
@@ -1,7 +1,7 @@
 package spark.examples
 
 import java.util.Random
-import Vector._
+import spark.util.Vector
 
 object LocalFileLR {
   val D = 10   // Numer of dimensions

--- a/examples/src/main/scala/spark/examples/LocalKMeans.scala
+++ b/examples/src/main/scala/spark/examples/LocalKMeans.scala
@@ -1,8 +1,7 @@
 package spark.examples
 
 import java.util.Random
-import Vector._
-import spark.SparkContext
+import spark.util.Vector
 import spark.SparkContext._
 import scala.collection.mutable.HashMap
 import scala.collection.mutable.HashSet

--- a/examples/src/main/scala/spark/examples/LocalLR.scala
+++ b/examples/src/main/scala/spark/examples/LocalLR.scala
@@ -1,7 +1,7 @@
 package spark.examples
 
 import java.util.Random
-import Vector._
+import spark.util.Vector
 
 object LocalLR {
   val N = 10000  // Number of data points

--- a/examples/src/main/scala/spark/examples/SparkHdfsLR.scala
+++ b/examples/src/main/scala/spark/examples/SparkHdfsLR.scala
@@ -2,7 +2,7 @@ package spark.examples
 
 import java.util.Random
 import scala.math.exp
-import Vector._
+import spark.util.Vector
 import spark._
 
 object SparkHdfsLR {

--- a/examples/src/main/scala/spark/examples/SparkKMeans.scala
+++ b/examples/src/main/scala/spark/examples/SparkKMeans.scala
@@ -1,8 +1,8 @@
 package spark.examples
 
 import java.util.Random
-import Vector._
 import spark.SparkContext
+import spark.util.Vector
 import spark.SparkContext._
 import scala.collection.mutable.HashMap
 import scala.collection.mutable.HashSet

--- a/examples/src/main/scala/spark/examples/SparkLR.scala
+++ b/examples/src/main/scala/spark/examples/SparkLR.scala
@@ -2,7 +2,7 @@ package spark.examples
 
 import java.util.Random
 import scala.math.exp
-import Vector._
+import spark.util.Vector
 import spark._
 
 object SparkLR {


### PR DESCRIPTION
Preliminary version of some updates to accumulators -- it works, but probably requires some discussion around the exact API.

I didn't want to break all existing accumulators, so to add an `addInPlace(T,Y)`
method meant creating a whole new type, which I've called `Accumulatable`. Also, I had to distinguish the old `+=` method from the new one.  I chose `+:=`, but that was rather arbitrary, I'm no expert on scala idioms.  (It seems that the old operator is really closer to `++=`, and the new one should be `+=`, but I guess we can't change that.)

I've also added tests for accumulators.  These include an example where the current value of an accumulator is read during a task.  The example application is stochastic gradient descent, where seeing the current value is really critical.  Should `accumulator.value` throw an exception (so the user doesn't think they're getting the global value), but maybe instead we expose `accumulator.localValue`?
