### PR TITLE
Logging Throwables in Info and Debug

### DIFF
--- a/core/src/main/scala/spark/Logging.scala
+++ b/core/src/main/scala/spark/Logging.scala
@@ -38,10 +38,10 @@ trait Logging {
 
   // Log methods that take Throwables (Exceptions/Errors) too
   def logInfo(msg: => String, throwable: Throwable) =
-    if (log.isInfoEnabled) log.info(msg)
+    if (log.isInfoEnabled) log.info(msg, throwable)
 
   def logDebug(msg: => String, throwable: Throwable) =
-    if (log.isDebugEnabled) log.debug(msg)
+    if (log.isDebugEnabled) log.debug(msg, throwable)
 
   def logWarning(msg: => String, throwable: Throwable) =
     if (log.isWarnEnabled) log.warn(msg, throwable)


### PR DESCRIPTION
Logging Throwables in logInfo and logDebug instead of swallowing them.
