### PR TITLE
Fix test checkpoint to reuse spark context defined in the class

### DIFF
--- a/core/src/test/scala/spark/RDDSuite.scala
+++ b/core/src/test/scala/spark/RDDSuite.scala
@@ -61,9 +61,8 @@ class RDDSuite extends FunSuite with BeforeAndAfter {
   }
 
   test("checkpointing") {
-    val sc = new SparkContext("local", "test")
+    sc = new SparkContext("local", "test")
     val rdd = sc.makeRDD(Array(1, 2, 3, 4), 2).flatMap(x => 1 to x).checkpoint()
     assert(rdd.collect().toList === List(1, 1, 2, 1, 2, 3, 1, 2, 3, 4))
-    sc.stop()
   }
 }


### PR DESCRIPTION
I sometimes see a crash in the after clause calling sc.stop and this seems to fix it
