### PR TITLE
Detect non-zero exit status from PipedRDD process

### DIFF
--- a/core/src/main/scala/spark/PipedRDD.scala
+++ b/core/src/main/scala/spark/PipedRDD.scala
@@ -57,7 +57,20 @@ class PipedRDD[T: ClassManifest](
     }.start()
 
     // Return an iterator that read lines from the process's stdout
-    Source.fromInputStream(proc.getInputStream).getLines
+    val lines = Source.fromInputStream(proc.getInputStream).getLines
+    return new Iterator[String] {
+      def next() = lines.next()
+      def hasNext = {
+        if (lines.hasNext) {
+          true
+        } else {
+          if (proc.waitFor() != 0) {
+            throw new Exception("Subprocess exited with non-zero exit status")
+          }
+          false
+        }
+      }
+    }
   }
 }
 

--- a/core/src/main/scala/spark/PipedRDD.scala
+++ b/core/src/main/scala/spark/PipedRDD.scala
@@ -64,8 +64,9 @@ class PipedRDD[T: ClassManifest](
         if (lines.hasNext) {
           true
         } else {
-          if (proc.waitFor() != 0) {
-            throw new Exception("Subprocess exited with non-zero exit status")
+          val exitStatus = proc.waitFor()
+          if (exitStatus != 0) {
+            throw new Exception("Subprocess exited with status " + exitStatus)
           }
           false
         }

--- a/core/src/test/scala/spark/PipedRDDSuite.scala
+++ b/core/src/test/scala/spark/PipedRDDSuite.scala
@@ -39,6 +39,15 @@ class PipedRDDSuite extends FunSuite with BeforeAndAfter {
     assert(c(1) === "LALALA")
   }
 
+  test("pipe with non-zero exit status") {
+    sc = new SparkContext("local", "test")
+    val nums = sc.makeRDD(Array(1, 2, 3, 4), 2)
+    val piped = nums.pipe("cat nonexistent_file")
+    intercept[SparkException] {
+      piped.collect()
+    }
+  }
+
 }
 
 


### PR DESCRIPTION
Changes PipedRDD to detect a non-zero exit status from its child process, rather than silently failing.
