### PR TITLE
Changes to SizeEstimator more accurate

### DIFF
--- a/core/src/main/scala/spark/SizeEstimator.scala
+++ b/core/src/main/scala/spark/SizeEstimator.scala
@@ -63,6 +63,9 @@ object SizeEstimator extends Logging {
   classInfos.put(classOf[Object], new ClassInfo(OBJECT_SIZE, Nil))
 
   private def getIsCompressedOops : Boolean = {
+    if (System.getProperty("spark.test.useCompressedOops") != null) {
+      return System.getProperty("spark.test.useCompressedOops").toBoolean 
+    }
     try {
       val hotSpotMBeanName = "com.sun.management:type=HotSpotDiagnostic";
       val server = ManagementFactory.getPlatformMBeanServer();

--- a/core/src/main/scala/spark/SizeEstimator.scala
+++ b/core/src/main/scala/spark/SizeEstimator.scala
@@ -37,6 +37,9 @@ object SizeEstimator {
   // TODO: Get this from jvm/system property
   val isCompressedOops = Runtime.getRuntime.maxMemory < (Integer.MAX_VALUE.toLong*2)
 
+  // Based on https://wikis.oracle.com/display/HotSpotInternals/CompressedOops
+  // section, "Which oops are compressed"
+
   // Minimum size of a java.lang.Object
   val OBJECT_SIZE = if (!is64bit) 8 else { 
     if(!isCompressedOops) {

--- a/core/src/test/scala/spark/BoundedMemoryCacheSuite.scala
+++ b/core/src/test/scala/spark/BoundedMemoryCacheSuite.scala
@@ -1,8 +1,9 @@
 package spark
 
 import org.scalatest.FunSuite
+import org.scalatest.PrivateMethodTester
 
-class BoundedMemoryCacheSuite extends FunSuite {
+class BoundedMemoryCacheSuite extends FunSuite with PrivateMethodTester {
   test("constructor test") {
     val cache = new BoundedMemoryCache(60)
     expect(60)(cache.getCapacity)
@@ -12,6 +13,8 @@ class BoundedMemoryCacheSuite extends FunSuite {
     // Set the arch to 64-bit and compressedOops to true to get a deterministic test-case 
     val oldArch = System.setProperty("os.arch", "amd64")
     val oldOops = System.setProperty("spark.test.useCompressedOops", "true")
+    val initialize = PrivateMethod[Unit]('initialize)
+    SizeEstimator invokePrivate initialize()
 
     val cache = new BoundedMemoryCache(60) {
       //TODO sorry about this, but there is not better way how to skip 'cacheTracker.dropEntry'

--- a/core/src/test/scala/spark/BoundedMemoryCacheSuite.scala
+++ b/core/src/test/scala/spark/BoundedMemoryCacheSuite.scala
@@ -4,28 +4,44 @@ import org.scalatest.FunSuite
 
 class BoundedMemoryCacheSuite extends FunSuite {
   test("constructor test") {
-    val cache = new BoundedMemoryCache(40)
-    expect(40)(cache.getCapacity)
+    val cache = new BoundedMemoryCache(60)
+    expect(60)(cache.getCapacity)
   }
 
   test("caching") {
-    val cache = new BoundedMemoryCache(40) {
+    // Set the arch to 64-bit and compressedOops to true to get a deterministic test-case 
+    val oldArch = System.setProperty("os.arch", "amd64")
+    val oldOops = System.setProperty("spark.test.useCompressedOops", "true")
+
+    val cache = new BoundedMemoryCache(60) {
       //TODO sorry about this, but there is not better way how to skip 'cacheTracker.dropEntry'
       override protected def reportEntryDropped(datasetId: Any, partition: Int, entry: Entry) {
         logInfo("Dropping key (%s, %d) of size %d to make space".format(datasetId, partition, entry.size))
       }
     }
     //should be OK
-    expect(CachePutSuccess(30))(cache.put("1", 0, "Meh"))
+    expect(CachePutSuccess(56))(cache.put("1", 0, "Meh"))
 
     //we cannot add this to cache (there is not enough space in cache) & we cannot evict the only value from
     //cache because it's from the same dataset
     expect(CachePutFailure())(cache.put("1", 1, "Meh"))
 
     //should be OK, dataset '1' can be evicted from cache
-    expect(CachePutSuccess(30))(cache.put("2", 0, "Meh"))
+    expect(CachePutSuccess(56))(cache.put("2", 0, "Meh"))
 
     //should fail, cache should obey it's capacity
     expect(CachePutFailure())(cache.put("3", 0, "Very_long_and_useless_string"))
+
+    if (oldArch != null) {
+      System.setProperty("os.arch", oldArch)
+    } else {
+      System.clearProperty("os.arch")
+    }
+
+    if (oldOops != null) {
+      System.setProperty("spark.test.useCompressedOops", oldOops)
+    } else {
+      System.clearProperty("spark.test.useCompressedOops")
+    }
   }
 }

--- a/core/src/test/scala/spark/SizeEstimatorSuite.scala
+++ b/core/src/test/scala/spark/SizeEstimatorSuite.scala
@@ -1,6 +1,7 @@
 package spark
 
 import org.scalatest.FunSuite
+import org.scalatest.BeforeAndAfterAll
 
 class DummyClass1 {}
 
@@ -17,61 +18,86 @@ class DummyClass4(val d: DummyClass3) {
   val x: Int = 0
 }
 
-class SizeEstimatorSuite extends FunSuite {
+class SizeEstimatorSuite extends FunSuite with BeforeAndAfterAll {
+  var oldArch: String = _
+  var oldOops: String = _
+
+  override def beforeAll() {
+    // Set the arch to 64-bit and compressedOops to true to get a deterministic test-case 
+    oldArch = System.setProperty("os.arch", "amd64")
+    oldOops = System.setProperty("spark.test.useCompressedOops", "true")
+  }
+
+  override def afterAll() {
+    if (oldArch != null) {
+      System.setProperty("os.arch", oldArch)
+    } else {
+      System.clearProperty("os.arch")
+    }
+
+    if (oldOops != null) {
+      System.setProperty("spark.test.useCompressedOops", oldOops)
+    } else {
+      System.clearProperty("spark.test.useCompressedOops")
+    }
+  }
+
   test("simple classes") {
-    expect(8)(SizeEstimator.estimate(new DummyClass1))
-    expect(12)(SizeEstimator.estimate(new DummyClass2))
-    expect(20)(SizeEstimator.estimate(new DummyClass3))
-    expect(16)(SizeEstimator.estimate(new DummyClass4(null)))
-    expect(36)(SizeEstimator.estimate(new DummyClass4(new DummyClass3)))
+    expect(16)(SizeEstimator.estimate(new DummyClass1))
+    expect(16)(SizeEstimator.estimate(new DummyClass2))
+    expect(24)(SizeEstimator.estimate(new DummyClass3))
+    expect(24)(SizeEstimator.estimate(new DummyClass4(null)))
+    expect(48)(SizeEstimator.estimate(new DummyClass4(new DummyClass3)))
   }
 
   test("strings") {
-    expect(24)(SizeEstimator.estimate(""))
-    expect(26)(SizeEstimator.estimate("a"))
-    expect(28)(SizeEstimator.estimate("ab"))
-    expect(40)(SizeEstimator.estimate("abcdefgh"))
+    expect(48)(SizeEstimator.estimate(""))
+    expect(56)(SizeEstimator.estimate("a"))
+    expect(56)(SizeEstimator.estimate("ab"))
+    expect(64)(SizeEstimator.estimate("abcdefgh"))
   }
 
   test("primitive arrays") {
-    expect(10)(SizeEstimator.estimate(new Array[Byte](10)))
-    expect(20)(SizeEstimator.estimate(new Array[Char](10)))
-    expect(20)(SizeEstimator.estimate(new Array[Short](10)))
-    expect(40)(SizeEstimator.estimate(new Array[Int](10)))
-    expect(80)(SizeEstimator.estimate(new Array[Long](10)))
-    expect(40)(SizeEstimator.estimate(new Array[Float](10)))
-    expect(80)(SizeEstimator.estimate(new Array[Double](10)))
-    expect(4000)(SizeEstimator.estimate(new Array[Int](1000)))
-    expect(8000)(SizeEstimator.estimate(new Array[Long](1000)))
+    expect(32)(SizeEstimator.estimate(new Array[Byte](10)))
+    expect(40)(SizeEstimator.estimate(new Array[Char](10)))
+    expect(40)(SizeEstimator.estimate(new Array[Short](10)))
+    expect(56)(SizeEstimator.estimate(new Array[Int](10)))
+    expect(96)(SizeEstimator.estimate(new Array[Long](10)))
+    expect(56)(SizeEstimator.estimate(new Array[Float](10)))
+    expect(96)(SizeEstimator.estimate(new Array[Double](10)))
+    expect(4016)(SizeEstimator.estimate(new Array[Int](1000)))
+    expect(8016)(SizeEstimator.estimate(new Array[Long](1000)))
   }
 
   test("object arrays") {
     // Arrays containing nulls should just have one pointer per element
-    expect(40)(SizeEstimator.estimate(new Array[String](10)))
-    expect(40)(SizeEstimator.estimate(new Array[AnyRef](10)))
+    expect(56)(SizeEstimator.estimate(new Array[String](10)))
+    expect(56)(SizeEstimator.estimate(new Array[AnyRef](10)))
 
     // For object arrays with non-null elements, each object should take one pointer plus
     // however many bytes that class takes. (Note that Array.fill calls the code in its
     // second parameter separately for each object, so we get distinct objects.)
-    expect(120)(SizeEstimator.estimate(Array.fill(10)(new DummyClass1))) 
-    expect(160)(SizeEstimator.estimate(Array.fill(10)(new DummyClass2))) 
-    expect(240)(SizeEstimator.estimate(Array.fill(10)(new DummyClass3))) 
-    expect(12 + 16)(SizeEstimator.estimate(Array(new DummyClass1, new DummyClass2)))
+    expect(216)(SizeEstimator.estimate(Array.fill(10)(new DummyClass1))) 
+    expect(216)(SizeEstimator.estimate(Array.fill(10)(new DummyClass2))) 
+    expect(296)(SizeEstimator.estimate(Array.fill(10)(new DummyClass3))) 
+    expect(56)(SizeEstimator.estimate(Array(new DummyClass1, new DummyClass2)))
 
     // Past size 100, our samples 100 elements, but we should still get the right size.
-    expect(24000)(SizeEstimator.estimate(Array.fill(1000)(new DummyClass3)))
+    expect(28016)(SizeEstimator.estimate(Array.fill(1000)(new DummyClass3)))
 
     // If an array contains the *same* element many times, we should only count it once.
     val d1 = new DummyClass1
-    expect(48)(SizeEstimator.estimate(Array.fill(10)(d1))) // 10 pointers plus 8-byte object
-    expect(408)(SizeEstimator.estimate(Array.fill(100)(d1))) // 100 pointers plus 8-byte object
+    expect(72)(SizeEstimator.estimate(Array.fill(10)(d1))) // 10 pointers plus 8-byte object
+    expect(432)(SizeEstimator.estimate(Array.fill(100)(d1))) // 100 pointers plus 8-byte object
 
     // Same thing with huge array containing the same element many times. Note that this won't
-    // return exactly 4008 because it can't tell that *all* the elements will equal the first
+    // return exactly 4032 because it can't tell that *all* the elements will equal the first
     // one it samples, but it should be close to that.
+
+    // TODO: If we sample 100 elements, this should always be 4176 ?
     val estimatedSize = SizeEstimator.estimate(Array.fill(1000)(d1))
     assert(estimatedSize >= 4000, "Estimated size " + estimatedSize + " should be more than 4000")
-    assert(estimatedSize <= 4100, "Estimated size " + estimatedSize + " should be less than 4100")
+    assert(estimatedSize <= 4200, "Estimated size " + estimatedSize + " should be less than 4100")
   }
 }
 


### PR DESCRIPTION
Motivation:
This patch is motivated by an observation that the amount of heap space used by
the BoundedMemoryCache is often much larger than what we account for.
For example running with 10 files from the RITA dataset[1] and 4GB for the cache,
we see the currBytes variable to be 3917.67. However analyzing the memory heap
with Eclipse MAT[2] shows that the BoundedMemoryCache in fact occupies 4360.55 MB.

Changes made:
This patch tries to address the discrepancy by making some changes to the
SizeEstimator. The object size and reference size are changed based on
the architecture in use and if or not CompressedOops are in use by the JVM. This
results in the object size changing from 8 to 12 or 16 and references being
either 4 or 8 bytes long.  We also account for the fact that arrays have an
object header + an int for the length. Lastly, this patch also account for the
fact that fields and objects are aligned to 8-byte boundaries by the JVM.
Changes are based on information from [3,4,5]

Tests:
Changes are verified by comparing the results from spark.SizeEstimator.estimate
to those from MAT. An example can be found in
https://github.com/shivaram/spark/tree/size-estimate-test/res where the first
100 lines from the 1990 dataset was used. The file spark-err-log.txt shows that
the size estimate was 25000 bytes which matches the size of the hashmap entry in
BoundedMemoryCache entry found in spark-bounded-memory.txt.

Also, a simple script that can be used to run such a test with any text file can
be found in the `size-estimate-test` tree as `run_size_estimate_test` With this
patch and the original dataset from the motivation, we get an estimate of
3878.81MB while MAT reports memory usage of 3879.61MB. The difference is 
explained below.

Caveats:
Arrays are still sampled during estimation and this could lead to small
variations as seen with the example above. Also, the patch uses HotSpot
diagnostic MXBean to figure out if compressed oops are being used by the JVM and
this may fail on non-hotspot JVMs. Finally, the patch has been tested only on
64-bit HotSpot JVMs (1.6.0_24 and 1.7.0_147-icedtea). I don't have access to a
32-bit machine to test it, but we can do it on EC2.

[1] http://stat-computing.org/dataexpo/2009/the-data.html
[2] http://eclipse.org/mat
[3] https://wikis.oracle.com/display/HotSpotInternals/CompressedOops
[4] http://kohlerm.blogspot.com/2008/12/how-much-memory-is-used-by-my-java.html
[5] http://lingpipe-blog.com/2010/06/22/the-unbearable-heaviness-jav-strings/ 
