### PR TITLE
publish-local should go to maven + ivy by default

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -22,7 +22,7 @@ object SparkBuild extends Build {
 
   // A configuration to set an alternative publishLocalConfiguration
   lazy val MavenCompile = config("m2r") extend(Compile)
-  lazy val publishLocalBoth = TaskKey[Unit]("pl", "publish local for m2 and ivy")
+  lazy val publishLocalBoth = TaskKey[Unit]("publish-local", "publish local for m2 and ivy")
 
   def sharedSettings = Defaults.defaultSettings ++ Seq(
     organization := "org.spark-project",


### PR DESCRIPTION
This makes publishing to ivy and maven the default behavior. Worked for me on a clean build.
