### PR TITLE
Fixed bug when fetching Jar dependencies.

### DIFF
--- a/core/src/main/scala/spark/executor/Executor.scala
+++ b/core/src/main/scala/spark/executor/Executor.scala
@@ -141,12 +141,12 @@ private[spark] class Executor extends Logging {
   private def updateDependencies(newFiles: HashMap[String, Long], newJars: HashMap[String, Long]) {
     // Fetch missing dependencies
     for ((name, timestamp) <- newFiles if currentFiles.getOrElse(name, -1L) < timestamp) {
-      logInfo("Fetching " + name)
+      logInfo("Fetching " + name + " with timestamp " + timestamp)
       Utils.fetchFile(name, new File("."))
       currentFiles(name) = timestamp
     }
-    for ((name, timestamp) <- newJars if currentFiles.getOrElse(name, -1L) < timestamp) {
-      logInfo("Fetching " + name)
+    for ((name, timestamp) <- newJars if currentJars.getOrElse(name, -1L) < timestamp) {
+      logInfo("Fetching " + name + " with timestamp " + timestamp)
       Utils.fetchFile(name, new File("."))
       currentJars(name) = timestamp
       // Add it to our class loader

--- a/core/src/main/scala/spark/scheduler/local/LocalScheduler.scala
+++ b/core/src/main/scala/spark/scheduler/local/LocalScheduler.scala
@@ -109,12 +109,12 @@ private[spark] class LocalScheduler(threads: Int, maxFailures: Int, sc: SparkCon
   private def updateDependencies(newFiles: HashMap[String, Long], newJars: HashMap[String, Long]) {
     // Fetch missing dependencies
     for ((name, timestamp) <- newFiles if currentFiles.getOrElse(name, -1L) < timestamp) {
-      logInfo("Fetching " + name)
+      logInfo("Fetching " + name + " with timestamp " + timestamp)
       Utils.fetchFile(name, new File("."))
       currentFiles(name) = timestamp
     }
-    for ((name, timestamp) <- newJars if currentFiles.getOrElse(name, -1L) < timestamp) {
-      logInfo("Fetching " + name)
+    for ((name, timestamp) <- newJars if currentJars.getOrElse(name, -1L) < timestamp) {
+      logInfo("Fetching " + name + " with timestamp " + timestamp)
       Utils.fetchFile(name, new File("."))
       currentJars(name) = timestamp
       // Add it to our class loader


### PR DESCRIPTION
Instead of checking currentFiles check currentJars. Came across this when testing some Shark queries.
