### PR TITLE
Removing credentials line in build.

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -78,7 +78,6 @@ object SparkBuild extends Build {
         Some("sonatype-staging"  at nexus + "service/local/staging/deploy/maven2")
     },
 
-    credentials += Credentials(Path.userHome / ".sbt" / "sonatype.credentials"),
 */
 
     libraryDependencies ++= Seq(


### PR DESCRIPTION
This line isn't needed - in fact it messes with the right way of resolving credentials automatically.
