### PR TITLE
Tweaked run file to live more happily with typesafe's debian package

### DIFF
--- a/run
+++ b/run
@@ -13,10 +13,33 @@ if [ -e $FWDIR/conf/spark-env.sh ] ; then
   . $FWDIR/conf/spark-env.sh
 fi
 
-# Check that SCALA_HOME has been specified
-if [ -z "$SCALA_HOME" ]; then
-  echo "SCALA_HOME is not set" >&2
-  exit 1
+if [ "$SPARK_LAUNCH_WITH_SCALA" == "1" ]; then
+  if [ `command -v scala` ]; then
+    RUNNER="scala"
+  else
+    if [ -z "$SCALA_HOME" ]; then
+      echo "SCALA_HOME is not set" >&2
+      exit 1
+    fi
+    RUNNER="${SCALA_HOME}/bin/scala"
+  fi
+else
+  if [ `command -v java` ]; then
+    RUNNER="java"
+  else
+    if [ -z "$JAVA_HOME" ]; then
+      echo "JAVA_HOME is not set" >&2
+      exit 1
+    fi
+    RUNNER="${JAVA_HOME}/bin/java"
+  fi
+  if [ -z "$SCALA_LIBRARY_PATH" ]; then
+    if [ -z "$SCALA_HOME" ]; then
+      echo "SCALA_HOME is not set" >&2
+      exit 1
+    fi
+    SCALA_LIBRARY_PATH="$SCALA_HOME/lib"
+  fi
 fi
 
 # Figure out how much memory to use per executor and set it as an environment
@@ -70,17 +93,11 @@ export CLASSPATH # Needed for spark-shell
 # the Spark shell, the wrapper is necessary to properly reset the terminal
 # when we exit, so we allow it to set a variable to launch with scala.
 if [ "$SPARK_LAUNCH_WITH_SCALA" == "1" ]; then
-  RUNNER="${SCALA_HOME}/bin/scala"
   EXTRA_ARGS=""     # Java options will be passed to scala as JAVA_OPTS
 else
-  CLASSPATH+=":$SCALA_HOME/lib/scala-library.jar"
-  CLASSPATH+=":$SCALA_HOME/lib/scala-compiler.jar"
-  CLASSPATH+=":$SCALA_HOME/lib/jline.jar"
-  if [ -n "$JAVA_HOME" ]; then
-    RUNNER="${JAVA_HOME}/bin/java"
-  else
-    RUNNER=java
-  fi
+  CLASSPATH+=":$SCALA_LIBRARY_PATH/scala-library.jar"
+  CLASSPATH+=":$SCALA_LIBRARY_PATH/scala-compiler.jar"
+  CLASSPATH+=":$SCALA_LIBRARY_PATH/jline.jar"
   # The JVM doesn't read JAVA_OPTS by default so we need to pass it in
   EXTRA_ARGS="$JAVA_OPTS"
 fi


### PR DESCRIPTION
The `run` script assumes a single-directory Scala installation structure with a `bin` and `lib` subdirectory. Unfortunately, that does not work well with Typesafe's Scala debian package which has this layout:

```
$ dpkg -L scala
/.
/usr
/usr/bin
/usr/bin/scalap
/usr/bin/scalac
/usr/bin/scala
/usr/bin/scaladoc
/usr/bin/fsc
/usr/share
/usr/share/scala
/usr/share/scala/plugins
/usr/share/scala/plugins/continuations.jar
/usr/share/java
/usr/share/java/scala-partest.jar
/usr/share/java/scala-swing.jar
/usr/share/java/scala-dbc.jar
/usr/share/java/jline.jar
/usr/share/java/scalacheck.jar
/usr/share/java/scala-library.jar
/usr/share/java/scala-compiler.jar
/usr/share/java/scalap.jar
/usr/share/doc
/usr/share/doc/scala
/usr/share/doc/scala/changelog.gz
/usr/share/doc/scala/copyright
/usr/share/man
/usr/share/man/man1
/usr/share/man/man1/fsc.1.gz
/usr/share/man/man1/scalap.1.gz
/usr/share/man/man1/scalac.1.gz
/usr/share/man/man1/scaladoc.1.gz
/usr/share/man/man1/scala.1.gz
```

This pull request changes the run script to:
- Use the `scala` binary as is if it is in the path, otherwise require `SCALA_HOME`
- Require either `SCALA_LIBRARY_PATH`, or if that is not defined, `SCALA_HOME` for running with `java` instead of `scala`
