### PR TITLE
Retry tasks when mesos slaves die

### DIFF
--- a/core/src/main/scala/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/spark/MapOutputTracker.scala
@@ -110,7 +110,10 @@ private[spark] class MapOutputTracker(actorSystem: ActorSystem, isMaster: Boolea
     var array = mapStatuses.get(shuffleId)
     if (array != null) {
       array.synchronized {
-        if (array(mapId).address == bmAddress) {
+        if (array(mapId) == null) {
+          logInfo("mapSustus is null for mapId: " + mapId)
+        }
+        else if (array(mapId).address == bmAddress) {
           array(mapId) = null
         }
       }

--- a/core/src/main/scala/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/spark/scheduler/DAGScheduler.scala
@@ -383,7 +383,7 @@ class DAGScheduler(taskSched: TaskScheduler) extends TaskSchedulerListener with 
     // Get our pending tasks and remember them in our pendingTasks entry
     val myPending = pendingTasks.getOrElseUpdate(stage, new HashSet)
     myPending.clear()
-    var tasks = ArrayBuffer[Task[_]]()
+    val tasks = ArrayBuffer[Task[_]]()
     if (stage.isShuffleMap) {
       for (p <- 0 until stage.numPartitions if stage.outputLocs(p) == Nil) {
         val locs = getPreferredLocs(stage.rdd, p)

--- a/core/src/main/scala/spark/scheduler/DAGSchedulerEvent.scala
+++ b/core/src/main/scala/spark/scheduler/DAGSchedulerEvent.scala
@@ -30,6 +30,8 @@ private[spark] case class CompletionEvent(
 
 private[spark] case class HostLost(host: String) extends DAGSchedulerEvent
 
+private[spark] case class RetryOffers(minTime: Long, lastPolled: Long) extends DAGSchedulerEvent
+
 private[spark] case class TaskSetFailed(taskSet: TaskSet, reason: String) extends DAGSchedulerEvent
 
 private[spark] case object StopDAGScheduler extends DAGSchedulerEvent

--- a/core/src/main/scala/spark/scheduler/TaskScheduler.scala
+++ b/core/src/main/scala/spark/scheduler/TaskScheduler.scala
@@ -16,6 +16,9 @@ private[spark] trait TaskScheduler {
   // Submit a sequence of tasks to run.
   def submitTasks(taskSet: TaskSet): Unit
 
+  // TODO this probably shouldn't be here, but I need a way to call reviveOffers on MesosSchedulerBackend
+  def reviveOffers() : Unit
+
   // Set a listener for upcalls. This is guaranteed to be set before submitTasks is called.
   def setListener(listener: TaskSchedulerListener): Unit
 

--- a/core/src/main/scala/spark/scheduler/cluster/ClusterScheduler.scala
+++ b/core/src/main/scala/spark/scheduler/cluster/ClusterScheduler.scala
@@ -196,7 +196,6 @@ private[spark] class ClusterScheduler(val sc: SparkContext)
     }
     if (failedHost != None) {
       listener.hostLost(failedHost.get)
-      backend.reviveOffers()
     }
     if (taskFailed) {
       // Also revive offers if a task had failed for some reason other than host lost

--- a/core/src/main/scala/spark/scheduler/cluster/ClusterScheduler.scala
+++ b/core/src/main/scala/spark/scheduler/cluster/ClusterScheduler.scala
@@ -23,7 +23,7 @@ private[spark] class ClusterScheduler(val sc: SparkContext)
   // How often to check for speculative tasks
   val SPECULATION_INTERVAL = System.getProperty("spark.speculation.interval", "100").toLong
 
-  val BLACKLIST_FAILED_HOSTS = System.getProperty("spark.blacklisthosts", "true").toBoolean
+  val BLACKLIST_FAILED_HOSTS = System.getProperty("spark.blacklisthosts", "false").toBoolean
   logInfo("Blacklist Hosts = " + BLACKLIST_FAILED_HOSTS)
 
   val activeTaskSets = new HashMap[String, TaskSetManager]
@@ -120,9 +120,10 @@ private[spark] class ClusterScheduler(val sc: SparkContext)
     synchronized {
       SparkEnv.set(sc.env)
       // Mark each slave as alive and remember its hostname
+      logInfo("got offers:" + offers)
       val filteredOffers = offers.filter{o =>
         if (blackListedHosts(o.hostname)) {
-          logInfo("ignoring offer of " + o + " because host is blaclisted")
+          logInfo("ignoring offer of " + o + " because host is blacklisted")
           false
         }
         else

--- a/core/src/main/scala/spark/scheduler/cluster/WorkerOffer.scala
+++ b/core/src/main/scala/spark/scheduler/cluster/WorkerOffer.scala
@@ -7,6 +7,6 @@ private[spark]
 class WorkerOffer(val slaveId: String, val hostname: String, val cores: Int) {
   override
   def toString() = {
-    slaveId + "\t" + hostname + "\t" + cores
+    "(" + slaveId + "," + hostname + "," + cores + ")"
   }
 }

--- a/core/src/main/scala/spark/scheduler/cluster/WorkerOffer.scala
+++ b/core/src/main/scala/spark/scheduler/cluster/WorkerOffer.scala
@@ -5,4 +5,8 @@ package spark.scheduler.cluster
  */
 private[spark]
 class WorkerOffer(val slaveId: String, val hostname: String, val cores: Int) {
+  override
+  def toString() = {
+    slaveId + "\t" + hostname + "\t" + cores
+  }
 }

--- a/core/src/main/scala/spark/scheduler/local/LocalScheduler.scala
+++ b/core/src/main/scala/spark/scheduler/local/LocalScheduler.scala
@@ -132,4 +132,6 @@ private[spark] class LocalScheduler(threads: Int, maxFailures: Int, sc: SparkCon
   }
 
   override def defaultParallelism() = threads
+
+  def reviveOffers() {} //should it be a no-op or exception?
 }

--- a/core/src/main/scala/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/spark/storage/BlockManager.scala
@@ -642,6 +642,7 @@ class BlockManager(val master: BlockManagerMaster, val serializer: Serializer, m
 
 
   val OLD_BLOCK_MODE = System.getProperty("spark.oldblockmode", "0").toInt
+  logInfo("OLD_BLOCK_MODE = " + OLD_BLOCK_MODE)
 
 
   /**

--- a/core/src/main/scala/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/spark/storage/BlockManager.scala
@@ -665,7 +665,8 @@ class BlockManager(val master: BlockManagerMaster, val serializer: Serializer, m
       logWarning("Block " + blockId + " already exists on this machine; not re-adding it")
       val oldBlock = blockInfo.get(blockId)
       OLD_BLOCK_MODE match {
-        case 0 => //no-op
+        case 0 =>
+          logInfo("no-op")
         case 1 =>
           logInfo("waiting for block to be ready")
           oldBlock.waitForReady()

--- a/core/src/main/scala/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/spark/storage/BlockManager.scala
@@ -641,7 +641,7 @@ class BlockManager(val master: BlockManagerMaster, val serializer: Serializer, m
   }
 
 
-  val OLD_BLOCK_MODE = System.getProperty("spark.oldblockmode", "0").toInt
+  val OLD_BLOCK_MODE = System.getProperty("spark.oldblockmode", "2").toInt
   logInfo("OLD_BLOCK_MODE = " + OLD_BLOCK_MODE)
 
 

--- a/core/src/test/scala/spark/scheduler/cluster/ClusterSchedulerSuite.scala
+++ b/core/src/test/scala/spark/scheduler/cluster/ClusterSchedulerSuite.scala
@@ -1,0 +1,16 @@
+package spark.scheduler.cluster
+
+import org.scalatest.FunSuite
+import org.scalatest.matchers.ShouldMatchers
+
+/**
+ *
+ */
+
+class ClusterSchedulerSuite extends FunSuite with ShouldMatchers {
+  test("getRealSlaveId") {
+    val origSlaveLost = "value: \"201211021432-3171224074-5050-18217-18\"\n"
+    ClusterScheduler.getRealSlaveId(origSlaveLost) should be ("201211021432-3171224074-5050-18217-18")
+    ClusterScheduler.getRealSlaveId("xyz") should be ("xyz")
+  }
+}


### PR DESCRIPTION
This addresses SPARK-604
https://spark-project.atlassian.net/browse/SPARK-604

This addresses several issues:
1) the slaveId from mesos in a slaveLost() msg was not getting parsed properly.
2) if a mesos slave died, spark simply hung (neither died nor retried)

Now, when a slave is lost, its correctly removed, and then we add a an event to the queue to resubmit the tasks.  That request waits a bit though, to see if the slave will reconnect (in this patch its hard-coded to 10s).

This could certainly use some review -- its was mostly just reverse-engineered, I wasn't sure about the exact contract between Spark & Mesos.  I have tested this on a cluster w/ several machines, where I manually killed one of the slaves.  Spark successfully recovers in that case -- though admittedly it seems like it needs to resubmit the current stage more than once before its happy.

Any suggestions on how to add unit tests for interactions w/ mesos?
