### PR TITLE
fix bug in getting slave id out of mesos

### DIFF
--- a/core/src/main/scala/spark/scheduler/mesos/MesosSchedulerBackend.scala
+++ b/core/src/main/scala/spark/scheduler/mesos/MesosSchedulerBackend.scala
@@ -272,7 +272,7 @@ private[spark] class MesosSchedulerBackend(
     synchronized {
       slaveIdsWithExecutors -= slaveId.getValue
     }
-    scheduler.slaveLost(slaveId.toString)
+    scheduler.slaveLost(slaveId.getValue)
   }
 
   override def executorLost(d: SchedulerDriver, e: ExecutorID, s: SlaveID, status: Int) {


### PR DESCRIPTION
Fixed this error:

12/11/05 11:22:13 INFO mesos.MesosSchedulerBackend: Mesos slave lost: 201211021432-3171224074-5050-18217-5
Exception in thread "Thread-338" java.util.NoSuchElementException: key not found: value: "201211021432-3171224074-5050-18217-5"

b/c we used to toString a protobuf instead of getting the value out of it.
