### PR TITLE
SPARK-624: make the default local IP customizable

### DIFF
--- a/core/src/main/scala/spark/Utils.scala
+++ b/core/src/main/scala/spark/Utils.scala
@@ -200,7 +200,7 @@ private object Utils extends Logging {
    * Get the local host's IP address in dotted-quad format (e.g. 1.2.3.4).
    */
   def localIpAddress(): String = {
-    val defaultIpOverride = System.getenv("SPARK_DEFAULT_LOCAL_IP")
+    val defaultIpOverride = System.getenv("SPARK_LOCAL_IP")
     if (defaultIpOverride != null)
       defaultIpOverride
     else

--- a/core/src/main/scala/spark/Utils.scala
+++ b/core/src/main/scala/spark/Utils.scala
@@ -199,7 +199,13 @@ private object Utils extends Logging {
   /**
    * Get the local host's IP address in dotted-quad format (e.g. 1.2.3.4).
    */
-  def localIpAddress(): String = InetAddress.getLocalHost.getHostAddress
+  def localIpAddress(): String = {
+    val defaultIpOverride = System.getenv("SPARK_DEFAULT_LOCAL_IP")
+    if (defaultIpOverride != null)
+      defaultIpOverride
+    else
+      InetAddress.getLocalHost.getHostAddress
+  }
 
   private var customHostname: Option[String] = None
 


### PR DESCRIPTION
It would be great to be able to specify the default local IP for Spark to run servers on. This way we would not have to modify /etc/hosts on our servers (we have reasons not to). https://spark-project.atlassian.net/browse/SPARK-624
