### PR TITLE
Minor tweaks to the debian build

### DIFF
--- a/repl/pom.xml
+++ b/repl/pom.xml
@@ -246,7 +246,9 @@
                   <goal>jdeb</goal>
                 </goals>
                 <configuration>
-                  <deb>${project.build.directory}/${project.artifactId}-${classifier}_${project.version}-${buildNumber}.deb</deb>
+                  <deb>${project.build.directory}/${project.artifactId}-${classifier}_${project.version}-${buildNumber}_all.deb</deb>
+                  <attach>false</attach>
+                  <compression>gzip</compression>
                   <dataSet>
                     <data>
                       <src>${project.build.directory}/${project.artifactId}-${project.version}-shaded-${classifier}.jar</src>


### PR DESCRIPTION
- Use the correct name for the the package file according to the debian rules.
- Don't attach the debian package to the maven build.
