### PR TITLE
SPARK_TEST_LOCAL_HOSTS and suppress shuffle block updates

### DIFF
--- a/core/src/main/scala/spark/deploy/LocalSparkCluster.scala
+++ b/core/src/main/scala/spark/deploy/LocalSparkCluster.scala
@@ -1,27 +1,28 @@
 package spark.deploy
 
+import scala.collection.mutable.ArrayBuffer
+
 import akka.actor.{ActorRef, Props, Actor, ActorSystem, Terminated}
 
+import spark.SparkException
 import spark.deploy.worker.Worker
 import spark.deploy.master.Master
 import spark.util.AkkaUtils
 import spark.{Logging, Utils}
 
-import scala.collection.mutable.ArrayBuffer
-
 private[spark]
 class LocalSparkCluster(numSlaves: Int, coresPerSlave: Int, memoryPerSlave: Int) extends Logging {
-  
+
   val localIpAddress = Utils.localIpAddress
-  
+
   var masterActor : ActorRef = _
   var masterActorSystem : ActorSystem = _
   var masterPort : Int = _
   var masterUrl : String = _
-  
+
   val slaveActorSystems = ArrayBuffer[ActorSystem]()
   val slaveActors = ArrayBuffer[ActorRef]()
-  
+
   def start() : String = {
     logInfo("Starting a local Spark cluster with " + numSlaves + " slaves.")
 
@@ -33,14 +34,33 @@ class LocalSparkCluster(numSlaves: Int, coresPerSlave: Int, memoryPerSlave: Int)
       Props(new Master(localIpAddress, masterPort, 0)), name = "Master")
     masterActor = actor
 
+    // By default, we assume 127.100.*.* are local hostnames that Spark can bind to. However,
+    // in some systems (e.g. some configuration of Mac OS X), 127.100.*.* is not usable names
+    // for localhost. In those cases, we allow the developer to specify a list of usable
+    // local hostnames in spark-env.sh using SPARK_TEST_LOCAL_HOSTS environmental variable.
+    // The list of hostnames should be separated by comma. Developers can edit /etc/hosts
+    // to generate a list (at least 2) of usable hostnames for Spark test suites. For example,
+    //
+    // export SPARK_TEST_LOCAL_HOSTS="localhost1, localhost2"
+    val localHosts: Array[String] =
+      if (System.getenv("SPARK_TEST_LOCAL_HOSTS") == null) {
+        // We can pretend to test distributed stuff by giving the slaves distinct hostnames.
+        // All of 127/8 should be a loopback, we use 127.100.*.* in hopes that it is
+        // sufficiently distinctive.
+        Array.tabulate[String](numSlaves) { slaveNum => "127.100.0." + (slaveNum + 1) }
+      } else {
+        val hosts = System.getenv("SPARK_TEST_LOCAL_HOSTS").split(".\\s+").take(numSlaves)
+        if (hosts.size < numSlaves) {
+          throw new SparkException(
+            "SPARK_TEST_LOCAL_HOSTS needs to specify at least " + numSlaves + " host names.")
+        }
+        hosts
+      }
+
     /* Start the Slaves */
-    for (slaveNum <- 1 to numSlaves) {
-      /* We can pretend to test distributed stuff by giving the slaves distinct hostnames.
-         All of 127/8 should be a loopback, we use 127.100.*.* in hopes that it is
-         sufficiently distinctive. */
-      val slaveIpAddress = "127.100.0." + (slaveNum % 256)
-      val (actorSystem, boundPort) = 
-        AkkaUtils.createActorSystem("sparkWorker" + slaveNum, slaveIpAddress, 0)
+    localHosts.zipWithIndex.foreach { case(slaveIpAddress, slaveNum) =>
+      val (actorSystem, boundPort) =
+        AkkaUtils.createActorSystem("sparkWorker" + (slaveNum + 1), slaveIpAddress, 0)
       slaveActorSystems += actorSystem
       val actor = actorSystem.actorOf(
         Props(new Worker(slaveIpAddress, boundPort, 0, coresPerSlave, memoryPerSlave, masterUrl)),

--- a/core/src/main/scala/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/spark/storage/BlockManager.scala
@@ -47,7 +47,7 @@ private[spark] class BlockManagerId(var ip: String, var port: Int) extends Exter
   }
 }
 
-private[spark] 
+private[spark]
 case class BlockException(blockId: String, message: String, ex: Exception = null)
 extends Exception(message)
 
@@ -155,6 +155,8 @@ class BlockManager(actorSystem: ActorSystem, val master: BlockManagerMaster,
    * will be made then.
    */
   private def reportAllBlocks() {
+    // Currently each block generates a new akka message. We might want to consider the option
+    // to consolidate these messages and send a bulk command.
     logInfo("Reporting " + blockInfo.size + " blocks to the master.")
     for (blockId <- blockInfo.keys) {
       if (!tryToReportBlockStatus(blockId)) {
@@ -200,33 +202,37 @@ class BlockManager(actorSystem: ActorSystem, val master: BlockManagerMaster,
   }
 
   /**
-   * Actually send a BlockUpdate message. Returns the mater's repsonse, which will be true if theo
-   * block was successfully recorded and false if the slave needs to reregister.
+   * Actually send a BlockUpdate message. Returns the mater's response, which will be true if the
+   * block was successfully recorded and false if the slave needs to re-register.
    */
   private def tryToReportBlockStatus(blockId: String): Boolean = {
-    val (curLevel, inMemSize, onDiskSize) = blockInfo.get(blockId) match {
+    val (curLevel, inMemSize, onDiskSize, tellMaster) = blockInfo.get(blockId) match {
       case null =>
-        (StorageLevel.NONE, 0L, 0L)
+        (StorageLevel.NONE, 0L, 0L, false)
       case info =>
         info.synchronized {
           info.level match {
             case null =>
-              (StorageLevel.NONE, 0L, 0L)
+              (StorageLevel.NONE, 0L, 0L, false)
             case level =>
               val inMem = level.useMemory && memoryStore.contains(blockId)
               val onDisk = level.useDisk && diskStore.contains(blockId)
               (
                 new StorageLevel(onDisk, inMem, level.deserialized, level.replication),
                 if (inMem) memoryStore.getSize(blockId) else 0L,
-                if (onDisk) diskStore.getSize(blockId) else 0L
+                if (onDisk) diskStore.getSize(blockId) else 0L,
+                info.tellMaster
               )
           }
         }
     }
-    return master.mustBlockUpdate(
-      BlockUpdate(blockManagerId, blockId, curLevel, inMemSize, onDiskSize))
-  }
 
+    if (tellMaster) {
+      master.mustBlockUpdate(BlockUpdate(blockManagerId, blockId, curLevel, inMemSize, onDiskSize))
+    } else {
+      true
+    }
+  }
 
   /**
    * Get locations of the block.

--- a/core/src/main/scala/spark/storage/BlockManagerMaster.scala
+++ b/core/src/main/scala/spark/storage/BlockManagerMaster.scala
@@ -215,7 +215,7 @@ private[spark] class BlockManagerMasterActor(val isLocal: Boolean) extends Actor
     val toRemove = new HashSet[BlockManagerId]
     for (info <- blockManagerInfo.values) {
       if (info.lastSeenMs < minSeenTime) {
-        logInfo("Removing BlockManager " + info.blockManagerId + " with no recent heart beats")
+        logWarning("Removing BlockManager " + info.blockManagerId + " with no recent heart beats")
         toRemove += info.blockManagerId
       }
     }
@@ -279,7 +279,7 @@ private[spark] class BlockManagerMasterActor(val isLocal: Boolean) extends Actor
     case ExpireDeadHosts =>
       expireDeadHosts()
 
-    case HeartBeat(blockManagerId) => 
+    case HeartBeat(blockManagerId) =>
       heartBeat(blockManagerId)
 
     case other =>
@@ -538,7 +538,7 @@ private[spark] class BlockManagerMaster(actorSystem: ActorSystem, isMaster: Bool
       val answer = askMaster(msg).asInstanceOf[Boolean]
       return Some(answer)
     } catch {
-      case e: Exception => 
+      case e: Exception =>
         logError("Failed in syncHeartBeat", e)
         return None
     }

--- a/sbt/sbt
+++ b/sbt/sbt
@@ -5,4 +5,9 @@ if [ "$MESOS_HOME" != "" ]; then
 fi
 export SPARK_HOME=$(cd "$(dirname $0)/.."; pwd)
 export SPARK_TESTING=1  # To put test classes on classpath
+
+if [ -e $SPARK_HOME/conf/spark-env.sh ] ; then
+  . $SPARK_HOME/conf/spark-env.sh
+fi
+
 java -Xmx1200M -XX:MaxPermSize=200m $EXTRA_ARGS -jar $SPARK_HOME/sbt/sbt-launch-*.jar "$@"


### PR DESCRIPTION
1. Allow setting SPARK_TEST_LOCAL_HOSTS to provide local Spark cluster with a list of usable hostnames.
2. Avoid sending block updates for shuffle blocks to the master when a
   slave's block manager comes back from hiatus.
