### PR TITLE
Mark hadoop dependencies provided in all library artifacts

### DIFF
--- a/bagel/pom.xml
+++ b/bagel/pom.xml
@@ -55,6 +55,7 @@
         <dependency>
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-core</artifactId>
+          <scope>provided</scope>
         </dependency>
       </dependencies>
       <build>
@@ -81,10 +82,12 @@
         <dependency>
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-core</artifactId>
+          <scope>provided</scope>
         </dependency>
         <dependency>
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-client</artifactId>
+          <scope>provided</scope>
         </dependency>
       </dependencies>
       <build>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -55,6 +55,7 @@
         <dependency>
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-core</artifactId>
+          <scope>provided</scope>
         </dependency>
       </dependencies>
       <build>
@@ -81,10 +82,12 @@
         <dependency>
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-core</artifactId>
+          <scope>provided</scope>
         </dependency>
         <dependency>
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-client</artifactId>
+          <scope>provided</scope>
         </dependency>
       </dependencies>
       <build>


### PR DESCRIPTION
The only exception is the repl, which I'm assuming won't be used as a library for now.
