### PR TITLE
Log preferred hosts

### DIFF
--- a/core/src/main/scala/spark/scheduler/cluster/TaskSetManager.scala
+++ b/core/src/main/scala/spark/scheduler/cluster/TaskSetManager.scala
@@ -201,7 +201,9 @@ private[spark] class TaskSetManager(
           val taskId = sched.newTaskId()
           // Figure out whether this should count as a preferred launch
           val preferred = isPreferredLocation(task, host)
-          val prefStr = if (preferred) "preferred" else "non-preferred"
+          val prefStr = if (preferred) "preferred" else
+            "non-preferred, not one of " +
+            task.preferredLocations.mkString(", ")
           logInfo("Starting task %s:%d as TID %s on slave %s: %s (%s)".format(
             taskSet.id, index, taskId, slaveId, host, prefStr))
           // Do various bookkeeping

--- a/core/src/main/scala/spark/scheduler/cluster/TaskSetManager.scala
+++ b/core/src/main/scala/spark/scheduler/cluster/TaskSetManager.scala
@@ -201,9 +201,8 @@ private[spark] class TaskSetManager(
           val taskId = sched.newTaskId()
           // Figure out whether this should count as a preferred launch
           val preferred = isPreferredLocation(task, host)
-          val prefStr = if (preferred) "preferred" else
-            "non-preferred, not one of " +
-            task.preferredLocations.mkString(", ")
+          val prefStr = if (preferred) "preferred"
+                        else "non-preferred, not one of " + task.preferredLocations.mkString(", ")
           logInfo("Starting task %s:%d as TID %s on slave %s: %s (%s)".format(
             taskSet.id, index, taskId, slaveId, host, prefStr))
           // Do various bookkeeping


### PR DESCRIPTION
Log preferred host names in case when running a task on a non-preferred one, because this sometimes indicates an inconsistency between the hostnames Spark workers and Hadoop datanodes use.
