### PR TITLE
Activate hadoop1 profile by default for maven builds

### DIFF
--- a/bagel/pom.xml
+++ b/bagel/pom.xml
@@ -47,7 +47,7 @@
       <id>hadoop1</id>
       <activation>
         <property>
-          <name>!hadoop</name>
+          <name>!hadoopVersion</name>
         </property>
       </activation>
       <dependencies>
@@ -79,7 +79,7 @@
       <id>hadoop2</id>
       <activation>
         <property>
-          <name>hadoop</name>
+          <name>hadoopVersion</name>
           <value>2</value>
         </property>
       </activation>

--- a/bagel/pom.xml
+++ b/bagel/pom.xml
@@ -45,6 +45,9 @@
   <profiles>
     <profile>
       <id>hadoop1</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <dependencies>
         <dependency>
           <groupId>org.spark-project</groupId>

--- a/bagel/pom.xml
+++ b/bagel/pom.xml
@@ -46,7 +46,9 @@
     <profile>
       <id>hadoop1</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!hadoop</name>
+        </property>
       </activation>
       <dependencies>
         <dependency>

--- a/bagel/pom.xml
+++ b/bagel/pom.xml
@@ -77,6 +77,12 @@
     </profile>
     <profile>
       <id>hadoop2</id>
+      <activation>
+        <property>
+          <name>hadoop</name>
+          <value>2</value>
+        </property>
+      </activation>
       <dependencies>
         <dependency>
           <groupId>org.spark-project</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -159,6 +159,9 @@
   <profiles>
     <profile>
       <id>hadoop1</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <dependencies>
         <dependency>
           <groupId>org.apache.hadoop</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -160,7 +160,9 @@
     <profile>
       <id>hadoop1</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!hadoop</name>
+        </property>
       </activation>
       <dependencies>
         <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -216,6 +216,12 @@
     </profile>
     <profile>
       <id>hadoop2</id>
+      <activation>
+        <property>
+          <name>hadoop</name>
+          <value>2</value>
+        </property>
+      </activation>
       <dependencies>
         <dependency>
           <groupId>org.apache.hadoop</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -161,7 +161,7 @@
       <id>hadoop1</id>
       <activation>
         <property>
-          <name>!hadoop</name>
+          <name>!hadoopVersion</name>
         </property>
       </activation>
       <dependencies>
@@ -218,7 +218,7 @@
       <id>hadoop2</id>
       <activation>
         <property>
-          <name>hadoop</name>
+          <name>hadoopVersion</name>
           <value>2</value>
         </property>
       </activation>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -47,7 +47,7 @@
       <id>hadoop1</id>
       <activation>
         <property>
-          <name>!hadoop</name>
+          <name>!hadoopVersion</name>
         </property>
       </activation>
       <dependencies>
@@ -79,7 +79,7 @@
       <id>hadoop2</id>
       <activation>
         <property>
-          <name>hadoop</name>
+          <name>hadoopVersion</name>
           <value>2</value>
         </property>
       </activation>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -45,6 +45,9 @@
   <profiles>
     <profile>
       <id>hadoop1</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <dependencies>
         <dependency>
           <groupId>org.spark-project</groupId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -46,7 +46,9 @@
     <profile>
       <id>hadoop1</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!hadoop</name>
+        </property>
       </activation>
       <dependencies>
         <dependency>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -77,6 +77,12 @@
     </profile>
     <profile>
       <id>hadoop2</id>
+      <activation>
+        <property>
+          <name>hadoop</name>
+          <value>2</value>
+        </property>
+      </activation>
       <dependencies>
         <dependency>
           <groupId>org.spark-project</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -483,9 +483,10 @@
       <id>hadoop1</id>
       <activation>
         <property>
-          <name>!hadoop</name>
+          <name>!hadoopVersion</name>
         </property>
       </activation>
+
       <properties>
         <hadoop.major.version>1</hadoop.major.version>
       </properties>
@@ -504,7 +505,7 @@
       <id>hadoop2</id>
       <activation>
         <property>
-          <name>hadoop</name>
+          <name>hadoopVersion</name>
           <value>2</value>
         </property>
       </activation>

--- a/pom.xml
+++ b/pom.xml
@@ -482,7 +482,9 @@
     <profile>
       <id>hadoop1</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!hadoop</name>
+        </property>
       </activation>
       <properties>
         <hadoop.major.version>1</hadoop.major.version>

--- a/pom.xml
+++ b/pom.xml
@@ -502,6 +502,12 @@
 
     <profile>
       <id>hadoop2</id>
+      <activation>
+        <property>
+          <name>hadoop</name>
+          <value>2</value>
+        </property>
+      </activation>
       <properties>
         <hadoop.major.version>2</hadoop.major.version>
       </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -481,6 +481,9 @@
   <profiles>
     <profile>
       <id>hadoop1</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <properties>
         <hadoop.major.version>1</hadoop.major.version>
       </properties>

--- a/repl-bin/pom.xml
+++ b/repl-bin/pom.xml
@@ -70,6 +70,9 @@
   <profiles>
     <profile>
       <id>hadoop1</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <properties>
         <classifier>hadoop1</classifier>
       </properties>

--- a/repl-bin/pom.xml
+++ b/repl-bin/pom.xml
@@ -72,7 +72,7 @@
       <id>hadoop1</id>
       <activation>
         <property>
-          <name>!hadoop</name>
+          <name>!hadoopVersion</name>
         </property>
       </activation>
       <properties>
@@ -117,7 +117,7 @@
       <id>hadoop2</id>
       <activation>
         <property>
-          <name>hadoop</name>
+          <name>hadoopVersion</name>
           <value>2</value>
         </property>
       </activation>

--- a/repl-bin/pom.xml
+++ b/repl-bin/pom.xml
@@ -115,6 +115,12 @@
     </profile>
     <profile>
       <id>hadoop2</id>
+      <activation>
+        <property>
+          <name>hadoop</name>
+          <value>2</value>
+        </property>
+      </activation>
       <properties>
         <classifier>hadoop2</classifier>
       </properties>

--- a/repl-bin/pom.xml
+++ b/repl-bin/pom.xml
@@ -71,7 +71,9 @@
     <profile>
       <id>hadoop1</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!hadoop</name>
+        </property>
       </activation>
       <properties>
         <classifier>hadoop1</classifier>

--- a/repl/pom.xml
+++ b/repl/pom.xml
@@ -121,6 +121,12 @@
     </profile>
     <profile>
       <id>hadoop2</id>
+      <activation>
+        <property>
+          <name>hadoop</name>
+          <value>2</value>
+        </property>
+      </activation>
       <properties>
         <classifier>hadoop2</classifier>
       </properties>

--- a/repl/pom.xml
+++ b/repl/pom.xml
@@ -74,7 +74,7 @@
       <id>hadoop1</id>
       <activation>
         <property>
-          <name>!hadoop</name>
+          <name>!hadoopVersion</name>
         </property>
       </activation>
       <properties>
@@ -123,7 +123,7 @@
       <id>hadoop2</id>
       <activation>
         <property>
-          <name>hadoop</name>
+          <name>hadoopVersion</name>
           <value>2</value>
         </property>
       </activation>

--- a/repl/pom.xml
+++ b/repl/pom.xml
@@ -73,7 +73,9 @@
     <profile>
       <id>hadoop1</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!hadoop</name>
+        </property>
       </activation>
       <properties>
         <classifier>hadoop1</classifier>

--- a/repl/pom.xml
+++ b/repl/pom.xml
@@ -72,6 +72,9 @@
   <profiles>
     <profile>
       <id>hadoop1</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <properties>
         <classifier>hadoop1</classifier>
       </properties>


### PR DESCRIPTION
While testing maven builds today, I realized that we don't have a default hadoop profile and its a bit clumsy to always use -Phadoop1. This patch makes hadoop1 the default profile for all the projects. hadoop2 can still be used with the -P switch.
