### PR TITLE
Retrieve jars to a flat directory so * can be used for the classpath.

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -38,6 +38,7 @@ object SparkBuild extends Build {
     scalacOptions := Seq(/*"-deprecation",*/ "-unchecked", "-optimize"), // -deprecation is too noisy due to usage of old Hadoop API, enable it once that's no longer an issue
     unmanagedJars in Compile <<= baseDirectory map { base => (base / "lib" ** "*.jar").classpath },
     retrieveManaged := true,
+    retrievePattern := "[type]s/[artifact](-[revision])(-[classifier]).[ext]",
     transitiveClassifiers in Scope.GlobalScope := Seq("sources"),
     testListeners <<= target.map(t => Seq(new eu.henkelmann.sbt.JUnitXmlTestsListener(t.getAbsolutePath))),
 

--- a/run
+++ b/run
@@ -75,16 +75,10 @@ CLASSPATH+=":$CORE_DIR/src/main/resources"
 CLASSPATH+=":$REPL_DIR/target/scala-$SCALA_VERSION/classes"
 CLASSPATH+=":$EXAMPLES_DIR/target/scala-$SCALA_VERSION/classes"
 if [ -e "$FWDIR/lib_managed" ]; then
-  for jar in `find "$FWDIR/lib_managed/jars" -name '*jar'`; do
-    CLASSPATH+=":$jar"
-  done
-  for jar in `find "$FWDIR/lib_managed/bundles" -name '*jar'`; do
-    CLASSPATH+=":$jar"
-  done
+  CLASSPATH+=":$FWDIR/lib_managed/jars/*"
+  CLASSPATH+=":$FWDIR/lib_managed/bundles/*"
 fi
-for jar in `find "$REPL_DIR/lib" -name '*jar'`; do
-  CLASSPATH+=":$jar"
-done
+CLASSPATH+=":$REPL_DIR/lib/*"
 for jar in `find "$REPL_DIR/target" -name 'spark-repl-*-shaded-hadoop*.jar'`; do
   CLASSPATH+=":$jar"
 done


### PR DESCRIPTION
This is somewhat trivial, but when doing "ps aux | grep java" to see what Spark processes were running, I noticed the classpath line is incredibly long.

Since JVM 6, the classpath arg can take "dir/*" and load all of the jars in that directory, which results in a much shorter command line in the ps output.

"dir/*" is not recursive though, so it requires changing Ivy to retrieve the jars in a flat manner.

I think this is a improvement, granted its minor, so understand if you're fine with the way things work now.
