### PR TITLE
Improve sleeping algorithm for rate limiting output streams

### DIFF
--- a/core/src/main/scala/spark/util/RateLimitedOutputStream.scala
+++ b/core/src/main/scala/spark/util/RateLimitedOutputStream.scala
@@ -31,7 +31,7 @@ class RateLimitedOutputStream(out: OutputStream, bytesPerSec: Int) extends Outpu
   def waitToWrite(numBytes: Int) {
     while (true) {
       val now = System.nanoTime
-      val elapsedSecs = SECONDS.convert(max(now - lastSyncTime, 1), NANOSECONDS)
+      val elapsedSecs = SECONDS.convert(math.max(now - lastSyncTime, 1), NANOSECONDS)
       val rate = bytesWrittenSinceSync.toDouble / elapsedSecs
       if (rate < bytesPerSec) {
         // It's okay to write; just update some variables and return

--- a/core/src/main/scala/spark/util/RateLimitedOutputStream.scala
+++ b/core/src/main/scala/spark/util/RateLimitedOutputStream.scala
@@ -41,6 +41,7 @@ class RateLimitedOutputStream(out: OutputStream, bytesPerSec: Int) extends Outpu
           lastSyncTime = now
           bytesWrittenSinceSync = numBytes
         }
+        return
       } else {
         // Calculate how much time we should sleep to bring ourselves to the desired rate.
         val sleepTime = MILLISECONDS.convert((bytesWrittenSinceSync / bytesPerSec - elapsedSecs), SECONDS)

--- a/core/src/main/scala/spark/util/RateLimitedOutputStream.scala
+++ b/core/src/main/scala/spark/util/RateLimitedOutputStream.scala
@@ -44,6 +44,7 @@ class RateLimitedOutputStream(out: OutputStream, bytesPerSec: Int) extends Outpu
         return
       } else {
         // Calculate how much time we should sleep to bring ourselves to the desired rate.
+        // Based on throttler in Kafka (https://github.com/kafka-dev/kafka/blob/master/core/src/main/scala/kafka/utils/Throttler.scala)
         val sleepTime = MILLISECONDS.convert((bytesWrittenSinceSync / bytesPerSec - elapsedSecs), SECONDS)
         if (sleepTime > 0) Thread.sleep(sleepTime)
       }

--- a/core/src/main/scala/spark/util/RateLimitedOutputStream.scala
+++ b/core/src/main/scala/spark/util/RateLimitedOutputStream.scala
@@ -6,8 +6,8 @@ import java.io.OutputStream
 import java.util.concurrent.TimeUnit._
 
 class RateLimitedOutputStream(out: OutputStream, bytesPerSec: Int) extends OutputStream {
-  val SyncIntervalNs = NANOSECONDS.convert(10, SECONDS)
-  val ChunkSize = 8192
+  val SYNC_INTERVAL = NANOSECONDS.convert(10, SECONDS)
+  val CHUNK_SIZE = 8192
   var lastSyncTime = System.nanoTime
   var bytesWrittenSinceSync: Long = 0
 
@@ -22,7 +22,7 @@ class RateLimitedOutputStream(out: OutputStream, bytesPerSec: Int) extends Outpu
 
   @tailrec
   override final def write(bytes: Array[Byte], offset: Int, length: Int) {
-    val writeSize = math.min(length - offset, ChunkSize)
+    val writeSize = math.min(length - offset, CHUNK_SIZE)
     if (writeSize > 0) {
       waitToWrite(writeSize)
       out.write(bytes, offset, writeSize)
@@ -46,7 +46,7 @@ class RateLimitedOutputStream(out: OutputStream, bytesPerSec: Int) extends Outpu
     if (rate < bytesPerSec) {
       // It's okay to write; just update some variables and return
       bytesWrittenSinceSync += numBytes
-      if (now > lastSyncTime + SyncIntervalNs) {
+      if (now > lastSyncTime + SYNC_INTERVAL) {
         // Sync interval has passed; let's resync
         lastSyncTime = now
         bytesWrittenSinceSync = numBytes

--- a/core/src/test/scala/spark/util/RateLimitedOutputStreamSuite.scala
+++ b/core/src/test/scala/spark/util/RateLimitedOutputStreamSuite.scala
@@ -1,0 +1,22 @@
+package spark.util
+
+import org.scalatest.FunSuite
+import java.io.ByteArrayOutputStream
+import java.util.concurrent.TimeUnit._
+
+class RateLimitedOutputStreamSuite extends FunSuite {
+
+  private def benchmark[U](f: => U): Long = {
+    val start = System.nanoTime
+    f
+    System.nanoTime - start
+  }
+
+  test("write") {
+    val underlying = new ByteArrayOutputStream
+    val data = "X" * 1000
+    val stream = new RateLimitedOutputStream(underlying, 100)
+    val elapsedNs = benchmark { stream.write(data.getBytes("UTF-8")) }
+    assert(SECONDS.convert(elapsedNs, NANOSECONDS) == 4)
+  }
+}

--- a/core/src/test/scala/spark/util/RateLimitedOutputStreamSuite.scala
+++ b/core/src/test/scala/spark/util/RateLimitedOutputStreamSuite.scala
@@ -14,8 +14,8 @@ class RateLimitedOutputStreamSuite extends FunSuite {
 
   test("write") {
     val underlying = new ByteArrayOutputStream
-    val data = "X" * 1000
-    val stream = new RateLimitedOutputStream(underlying, 100)
+    val data = "X" * 41000
+    val stream = new RateLimitedOutputStream(underlying, 10000)
     val elapsedNs = benchmark { stream.write(data.getBytes("UTF-8")) }
     assert(SECONDS.convert(elapsedNs, NANOSECONDS) == 4)
   }

--- a/core/src/test/scala/spark/util/RateLimitedOutputStreamSuite.scala
+++ b/core/src/test/scala/spark/util/RateLimitedOutputStreamSuite.scala
@@ -18,5 +18,6 @@ class RateLimitedOutputStreamSuite extends FunSuite {
     val stream = new RateLimitedOutputStream(underlying, 10000)
     val elapsedNs = benchmark { stream.write(data.getBytes("UTF-8")) }
     assert(SECONDS.convert(elapsedNs, NANOSECONDS) == 4)
+    assert(underlying.toString("UTF-8") == data)
   }
 }


### PR DESCRIPTION
This pull request contains minor cleanup, and also a more accurate approach to sleeping when we determine that we need to throttle down the rate at which we are writing bytes. This is based on the way Kafka does it via their Throttler utility class. Previously we were always sleeping a static 5ms when throttling down.
