### PR TITLE
Generate FetchFailedException even for cached missing map outputs

### DIFF
--- a/core/src/main/scala/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/spark/MapOutputTracker.scala
@@ -139,8 +139,8 @@ private[spark] class MapOutputTracker(actorSystem: ActorSystem, isMaster: Boolea
               case e: InterruptedException =>
             }
           }
-          return mapStatuses.get(shuffleId).map(status =>
-            (status.address, MapOutputTracker.decompressSize(status.compressedSizes(reduceId))))
+          return MapOutputTracker.convertMapStatuses(shuffleId, reduceId,
+                                                     mapStatuses.get(shuffleId))
         } else {
           fetching += shuffleId
         }
@@ -156,21 +156,15 @@ private[spark] class MapOutputTracker(actorSystem: ActorSystem, isMaster: Boolea
         fetchedStatuses = deserializeStatuses(fetchedBytes)
         logInfo("Got the output locations")
         mapStatuses.put(shuffleId, fetchedStatuses)
-        if (fetchedStatuses.contains(null)) {
-          throw new FetchFailedException(null, shuffleId, -1, reduceId,
-            new Exception("Missing an output location for shuffle " + shuffleId))
-        }
       } finally {
         fetching.synchronized {
           fetching -= shuffleId
           fetching.notifyAll()
         }
       }
-      return fetchedStatuses.map(s =>
-        (s.address, MapOutputTracker.decompressSize(s.compressedSizes(reduceId))))
+      return MapOutputTracker.convertMapStatuses(shuffleId, reduceId, fetchedStatuses)
     } else {
-      return statuses.map(s =>
-        (s.address, MapOutputTracker.decompressSize(s.compressedSizes(reduceId))))
+      return MapOutputTracker.convertMapStatuses(shuffleId, reduceId, statuses)
     }
   }
 
@@ -257,6 +251,28 @@ private[spark] class MapOutputTracker(actorSystem: ActorSystem, isMaster: Boolea
 
 private[spark] object MapOutputTracker {
   private val LOG_BASE = 1.1
+
+  // Convert an array of MapStatuses to locations and sizes for a given reduce ID. If
+  // any of the statuses is null (indicating a missing location due to a failed mapper),
+  // throw a FetchFailedException.
+  def convertMapStatuses(
+        shuffleId: Int,
+        reduceId: Int,
+        statuses: Array[MapStatus]): Array[(BlockManagerId, Long)] = {
+    if (statuses == null) {
+      throw new FetchFailedException(null, shuffleId, -1, reduceId,
+        new Exception("Missing all output locations for shuffle " + shuffleId))
+    }
+    statuses.map {
+      status => 
+        if (status == null) {
+          throw new FetchFailedException(null, shuffleId, -1, reduceId,
+            new Exception("Missing an output location for shuffle " + shuffleId))
+        } else {
+          (status.address, decompressSize(status.compressedSizes(reduceId)))
+        }
+    }
+  }
 
   /**
    * Compress a size in bytes to 8 bits for efficient reporting of map output sizes.

--- a/core/src/test/scala/spark/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/spark/MapOutputTrackerSuite.scala
@@ -1,12 +1,18 @@
 package spark
 
 import org.scalatest.FunSuite
+import org.scalatest.BeforeAndAfter
 
 import akka.actor._
 import spark.scheduler.MapStatus
 import spark.storage.BlockManagerId
+import spark.util.AkkaUtils
 
-class MapOutputTrackerSuite extends FunSuite {
+class MapOutputTrackerSuite extends FunSuite with BeforeAndAfter {
+  after {
+    System.clearProperty("spark.master.port")
+  }
+ 
   test("compressSize") {
     assert(MapOutputTracker.compressSize(0L) === 0)
     assert(MapOutputTracker.compressSize(1L) === 1)
@@ -71,6 +77,78 @@ class MapOutputTrackerSuite extends FunSuite {
     // The remaining reduce task might try to grab the output dispite the shuffle failure;
     // this should cause it to fail, and the scheduler will ignore the failure due to the
     // stage already being aborted.
-    intercept[Exception] { tracker.getServerStatuses(10, 1) }
+    intercept[FetchFailedException] { tracker.getServerStatuses(10, 1) }
+  }
+
+  test("remote fetch") {
+    val (actorSystem, boundPort) =
+      AkkaUtils.createActorSystem("test", "localhost", 0)
+    System.setProperty("spark.master.port", boundPort.toString)
+    val masterTracker = new MapOutputTracker(actorSystem, true)
+    val slaveTracker = new MapOutputTracker(actorSystem, false)
+    masterTracker.registerShuffle(10, 1)
+    masterTracker.incrementGeneration()
+    slaveTracker.updateGeneration(masterTracker.getGeneration)
+    intercept[FetchFailedException] { slaveTracker.getServerStatuses(10, 0) }
+
+    val compressedSize1000 = MapOutputTracker.compressSize(1000L)
+    val size1000 = MapOutputTracker.decompressSize(compressedSize1000)
+    masterTracker.registerMapOutput(10, 0, new MapStatus(
+      new BlockManagerId("hostA", 1000), Array(compressedSize1000)))
+    masterTracker.incrementGeneration()
+    slaveTracker.updateGeneration(masterTracker.getGeneration)
+    assert(slaveTracker.getServerStatuses(10, 0).toSeq ===
+           Seq((new BlockManagerId("hostA", 1000), size1000)))
+
+    masterTracker.unregisterMapOutput(10, 0, new BlockManagerId("hostA", 1000))
+    masterTracker.incrementGeneration()
+    slaveTracker.updateGeneration(masterTracker.getGeneration)
+    intercept[FetchFailedException] { slaveTracker.getServerStatuses(10, 0) }
+  }
+
+  test("simulatenous fetch fails") {
+    val dummyActorSystem = ActorSystem("testDummy")
+    val dummyTracker = new MapOutputTracker(dummyActorSystem, true)
+    dummyTracker.registerShuffle(10, 1)
+    // val compressedSize1000 = MapOutputTracker.compressSize(1000L)
+    // val size100 = MapOutputTracker.decompressSize(compressedSize1000)
+    // dummyTracker.registerMapOutput(10, 0, new MapStatus(
+    //   new BlockManagerId("hostA", 1000), Array(compressedSize1000)))
+    val serializedMessage = dummyTracker.getSerializedLocations(10)
+
+    val (actorSystem, boundPort) =
+      AkkaUtils.createActorSystem("test", "localhost", 0)
+    System.setProperty("spark.master.port", boundPort.toString)
+    val delayResponseLock = new java.lang.Object
+    val delayResponseActor = actorSystem.actorOf(Props(new Actor {
+      override def receive = {
+        case GetMapOutputStatuses(shuffleId: Int, requester: String) =>
+          delayResponseLock.synchronized {
+            sender ! serializedMessage
+          }
+      }
+    }), name = "MapOutputTracker")
+    val slaveTracker = new MapOutputTracker(actorSystem, false)
+    var firstFailed = false
+    var secondFailed = false
+    val firstFetch = new Thread {
+      override def run() {
+        intercept[FetchFailedException] { slaveTracker.getServerStatuses(10, 0) }
+        firstFailed = true
+      }
+    }
+    val secondFetch = new Thread {
+      override def run() {
+        intercept[FetchFailedException] { slaveTracker.getServerStatuses(10, 0) }
+        secondFailed = true
+      }
+    }
+    delayResponseLock.synchronized {
+      firstFetch.start
+      secondFetch.start
+    }
+    firstFetch.join
+    secondFetch.join
+    assert(firstFailed && secondFailed)
   }
 }

--- a/core/src/test/scala/spark/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/spark/MapOutputTrackerSuite.scala
@@ -81,6 +81,7 @@ class MapOutputTrackerSuite extends FunSuite with BeforeAndAfter {
   }
 
   test("remote fetch") {
+    System.clearProperty("spark.master.host")
     val (actorSystem, boundPort) =
       AkkaUtils.createActorSystem("test", "localhost", 0)
     System.setProperty("spark.master.port", boundPort.toString)
@@ -107,6 +108,7 @@ class MapOutputTrackerSuite extends FunSuite with BeforeAndAfter {
   }
 
   test("simulatenous fetch fails") {
+    System.clearProperty("spark.master.host")
     val dummyActorSystem = ActorSystem("testDummy")
     val dummyTracker = new MapOutputTracker(dummyActorSystem, true)
     dummyTracker.registerShuffle(10, 1)


### PR DESCRIPTION
Currently, MapOutputTracker generates a FetchFailedException if it fetches new map output locations from the master and finds that at least one map output is missing, but it generates a NullPointerException when the missing map output location is cached locally. (This is likely to occur when two parallel reduce tasks ask for the map output locations at roughly the same time.) This patch generates a FetchFailedException instead (triggering the correct fault-handling code). It also includes some tests which trigger MapOutputTracker's output location fetching code.
