### PR TITLE
Updated SCALA_VERSION in run2.cmd to match runtime version of Scala

### DIFF
--- a/run2.cmd
+++ b/run2.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-set SCALA_VERSION=2.9.1
+set SCALA_VERSION=2.9.2
 
 rem Figure out where the Spark framework is installed
 set FWDIR=%~dp0


### PR DESCRIPTION
Changed the SCALA_VERSION to 2.9.2, so that the classes can be found when the classpath is expanded.
