### PR TITLE
HttpBroadcast server cache by default in spark.local.dir instead of java.io.tmpdir

### DIFF
--- a/core/src/main/scala/spark/broadcast/HttpBroadcast.scala
+++ b/core/src/main/scala/spark/broadcast/HttpBroadcast.scala
@@ -89,7 +89,7 @@ private object HttpBroadcast extends Logging {
   }
 
   private def createServer() {
-    broadcastDir = Utils.createTempDir()
+    broadcastDir = Utils.createTempDir(System.getProperty("spark.local.dir", System.getProperty("java.io.tmpdir")))
     server = new HttpServer(broadcastDir)
     server.start()
     serverUri = server.uri


### PR DESCRIPTION
The HttpBroadcast server cache is by default writing in java.io.tmpdir, which is misleading because you would expect this data to be in the Spark scratch space.
