### PR TITLE
be sure to set class loader of kryo instances

### DIFF
--- a/core/src/main/scala/spark/KryoSerializer.scala
+++ b/core/src/main/scala/spark/KryoSerializer.scala
@@ -275,5 +275,8 @@ class KryoSerializer extends spark.serializer.Serializer with Logging {
     kryo
   }
 
-  def newInstance(): SerializerInstance = new KryoSerializerInstance(this)
+  def newInstance(): SerializerInstance = {
+    this.kryo.setClassLoader(Thread.currentThread().getContextClassLoader)
+    new KryoSerializerInstance(this)
+  }
 }


### PR DESCRIPTION
Maybe I'm doing something wrong, but w/out this change I get exceptions if I try to deserialize custom classes that I haven't registered.  Eg., if I try to shuffle a custom case class:

case class MyCaseClass(val v: Int, val x: String)

I would get an exception:

13/01/21 16:06:54 INFO cluster.TaskSetManager: Loss was due to com.esotericsoftware.kryo.SerializationException: Unable to deserialize object of type: scala.Tuple2
    at com.esotericsoftware.kryo.Kryo.readClassAndObject(Kryo.java:571)
    at com.esotericsoftware.kryo.ObjectBuffer.readClassAndObject(ObjectBuffer.java:92)
    at spark.KryoDeserializationStream.readObject(KryoSerializer.scala:95)
    at spark.serializer.DeserializationStream$$anon$1.getNext(Serializer.scala:82)
    at spark.serializer.DeserializationStream$$anon$1.hasNext(Serializer.scala:92)
    at scala.collection.Iterator$class.foreach(Iterator.scala:660)
    at spark.serializer.DeserializationStream$$anon$1.foreach(Serializer.scala:75)
    at spark.BlockStoreShuffleFetcher$$anonfun$fetch$6.apply(BlockStoreShuffleFetcher.scala:38)
    at spark.BlockStoreShuffleFetcher$$anonfun$fetch$6.apply(BlockStoreShuffleFetcher.scala:34)
    at scala.collection.Iterator$class.foreach(Iterator.scala:660)
    at scala.collection.Iterator$$anon$22.foreach(Iterator.scala:382)
    at spark.BlockStoreShuffleFetcher.fetch(BlockStoreShuffleFetcher.scala:34)
...

this change makes those errors go away
