### PR TITLE
Add an Avro dependency to REPL to make it compile with Hadoop 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -542,6 +542,17 @@
             <artifactId>hadoop-client</artifactId>
             <version>2.0.0-mr1-cdh${cdh.version}</version>
           </dependency>
+          <!-- Specify Avro version because Kafka also has it as a dependency -->
+          <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <version>1.7.1.cloudera.2</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro-ipc</artifactId>
+            <version>1.7.1.cloudera.2</version>
+          </dependency>
         </dependencies>
       </dependencyManagement>
     </profile>

--- a/repl/pom.xml
+++ b/repl/pom.xml
@@ -175,6 +175,16 @@
           <artifactId>hadoop-client</artifactId>
           <scope>provided</scope>
         </dependency>
+        <dependency>
+          <groupId>org.apache.avro</groupId>
+          <artifactId>avro</artifactId>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.avro</groupId>
+          <artifactId>avro-ipc</artifactId>
+          <scope>provided</scope>
+        </dependency>
       </dependencies>
       <build>
         <plugins>


### PR DESCRIPTION
Without this, I was getting the following compilation error:

```
error: error while loading Path, Missing dependency 'class org.apache.avro.reflect.Stringable', required by /Users/mbautin/.m2/repository/org/apache/hadoop/hadoop-common/2.0.0-cdh4.1.2/hadoop-common-2.0.0-cdh4.1.2.jar(org/apache/hadoop/fs/Path.class)
/wd/spark/repl/src/main/scala/spark/repl/ExecutorClassLoader.scala:37: error: org.apache.hadoop.fs.Path does not have a constructor
          fileSystem.open(new Path(directory, pathInDirectory))
```
