### PR TITLE
Fix stdout redirection in PySpark.

### DIFF
--- a/python/pyspark/tests.py
+++ b/python/pyspark/tests.py
@@ -108,5 +108,14 @@ class TestAddFile(PySparkTestCase):
         self.assertEqual("Hello World!", UserClass().hello())
 
 
+class TestIO(PySparkTestCase):
+
+    def test_stdout_redirection(self):
+        import subprocess
+        def func(x):
+            subprocess.check_call('ls', shell=True)
+        self.sc.parallelize([1]).foreach(func)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -1,6 +1,7 @@
 """
 Worker that receives input from Piped RDD.
 """
+import os
 import sys
 import traceback
 from base64 import standard_b64decode
@@ -15,8 +16,8 @@ from pyspark.serializers import write_with_length, read_with_length, write_int, 
 
 
 # Redirect stdout to stderr so that users must return values from functions.
-old_stdout = sys.stdout
-sys.stdout = sys.stderr
+old_stdout = os.fdopen(os.dup(1), 'w')
+os.dup2(2, 1)
 
 
 def load_obj():


### PR DESCRIPTION
Fixes a stdout redirection problem [described on the spark-users mailing list](https://groups.google.com/d/topic/spark-users/wGX5jO0w1Mw/discussion).  Thanks to @woggling for suggesting `os.open / os.dup2`.
