### PR TITLE
Once we find a split with no block, we don't have to look for more.

### DIFF
--- a/core/src/main/scala/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/spark/scheduler/DAGScheduler.scala
@@ -176,9 +176,7 @@ class DAGScheduler(taskSched: TaskScheduler) extends TaskSchedulerListener with 
     def visit(rdd: RDD[_]) {
       if (!visited(rdd)) {
         visited += rdd
-        val locs = getCacheLocs(rdd)
-        val atLeastOneMissing = (0 until rdd.splits.size).exists(locs(_) == Nil)
-        if (atLeastOneMissing) {
+        if (getCacheLocs(rdd).contains(Nil)) {
           for (dep <- rdd.dependencies) {
             dep match {
               case shufDep: ShuffleDependency[_,_] =>


### PR DESCRIPTION
As far as I can tell, once we find a locs(p) == Nil, and that rdd's dependencies as stages, we don't need to continue the loop looking for more locs(p)s because we'll just end up adding the same stages (which has no effect since we're adding them to a hash set that they've already been added too).

Admittedly, this won't have a huge affect on runtime, because even with a large number of splits, this should be a fast loop, but nonetheless it made me think slightly when I saw it.
