### PR TITLE
SPARK-532 Log something when no resources have been offered in the cluster

### DIFF
--- a/core/src/main/scala/spark/scheduler/cluster/TaskSetManager.scala
+++ b/core/src/main/scala/spark/scheduler/cluster/TaskSetManager.scala
@@ -43,7 +43,6 @@ private[spark] class TaskSetManager(sched: ClusterScheduler, val taskSet: TaskSe
   val numFailures = new Array[Int](numTasks)
   val taskAttempts = Array.fill[List[TaskInfo]](numTasks)(Nil)
   var tasksFinished = 0
-  val creationTime = System.currentTimeMillis
 
   // Last time when we launched a preferred task (for delay scheduling)
   var lastPreferredLaunchTime = System.currentTimeMillis

--- a/core/src/main/scala/spark/scheduler/cluster/TaskSetManager.scala
+++ b/core/src/main/scala/spark/scheduler/cluster/TaskSetManager.scala
@@ -44,7 +44,6 @@ private[spark] class TaskSetManager(sched: ClusterScheduler, val taskSet: TaskSe
   val taskAttempts = Array.fill[List[TaskInfo]](numTasks)(Nil)
   var tasksFinished = 0
   val creationTime = System.currentTimeMillis
-  var receivedOffers = 0
 
   // Last time when we launched a preferred task (for delay scheduling)
   var lastPreferredLaunchTime = System.currentTimeMillis
@@ -97,8 +96,6 @@ private[spark] class TaskSetManager(sched: ClusterScheduler, val taskSet: TaskSe
   for (i <- (0 until numTasks).reverse) {
     addPendingTask(i)
   }
-
-  if (!TaskSetManager.firstTaskSet.isDefined) TaskSetManager.firstTaskSet = Some(this)
 
   // Add a task to all the pending-task lists that it should be on.
   private def addPendingTask(index: Int) {
@@ -192,7 +189,6 @@ private[spark] class TaskSetManager(sched: ClusterScheduler, val taskSet: TaskSe
 
   // Respond to an offer of a single slave from the scheduler by finding a task
   def slaveOffer(execId: String, host: String, availableCpus: Double): Option[TaskDescription] = {
-    receivedOffers += 1
     if (tasksFinished < numTasks && availableCpus >= CPUS_PER_TASK) {
       val time = System.currentTimeMillis
       val localOnly = (time - lastPreferredLaunchTime < LOCALITY_WAIT)
@@ -431,8 +427,4 @@ private[spark] class TaskSetManager(sched: ClusterScheduler, val taskSet: TaskSe
     }
     return foundTasks
   }
-}
-
-object TaskSetManager {
-  var firstTaskSet: Option[TaskSetManager] = None
 }


### PR DESCRIPTION
This solves a long-standing usability issue, that jobs seem to just "hang" when they are submitted to a cluster without enough resources.

This patch adds two warning messages that address two variants of this problem:

(a) A job is submitted to the cluster scheduler, but there aren't any slaves registered yet with the scheduler. Therefore, no offers are made.
(b) Slaves are registered with the Standalone scheduler, but none have enough memory to launch executors on.

This is a preliminary patch which handles the case where these errors happen on cluster startup. Some types of "starvation" are not covered, such as a job arriving in an already full cluster that needs to wait until other jobs finished (it's much more subjective what to log and when in that situation).
