### PR TITLE
Increase DriverSuite timeout.

### DIFF
--- a/core/src/test/scala/spark/DriverSuite.scala
+++ b/core/src/test/scala/spark/DriverSuite.scala
@@ -9,10 +9,11 @@ import org.scalatest.time.SpanSugar._
 
 class DriverSuite extends FunSuite with Timeouts {
   test("driver should exit after finishing") {
+    assert(System.getenv("SPARK_HOME") != null)
     // Regression test for SPARK-530: "Spark driver process doesn't exit after finishing"
     val masters = Table(("master"), ("local"), ("local-cluster[2,1,512]"))
     forAll(masters) { (master: String) =>
-      failAfter(10 seconds) {
+      failAfter(30 seconds) {
         Utils.execute(Seq("./run", "spark.DriverWithoutCleanup", master),
           new File(System.getenv("SPARK_HOME")))
       }


### PR DESCRIPTION
This was timing out for me, plus fails if SPARK_HOME isn't set, so added an explicit assert for that.
