### PR TITLE
include jobid in Executor commandline args

### DIFF
--- a/core/src/main/scala/spark/deploy/worker/ExecutorRunner.scala
+++ b/core/src/main/scala/spark/deploy/worker/ExecutorRunner.scala
@@ -77,7 +77,7 @@ private[spark] class ExecutorRunner(
     val command = jobDesc.command
     val script = if (System.getProperty("os.name").startsWith("Windows")) "run.cmd" else "run";
     val runScript = new File(sparkHome, script).getCanonicalPath
-    Seq(runScript, command.mainClass) ++ command.arguments.map(substituteVariables)
+    Seq(runScript, command.mainClass) ++ (command.arguments ++ Seq(jobId)).map(substituteVariables)
   }
 
   /** Spawn a thread that will redirect a given stream to a file */

--- a/core/src/main/scala/spark/executor/StandaloneExecutorBackend.scala
+++ b/core/src/main/scala/spark/executor/StandaloneExecutorBackend.scala
@@ -68,8 +68,9 @@ private[spark] object StandaloneExecutorBackend {
   }
 
   def main(args: Array[String]) {
-    if (args.length != 4) {
-      System.err.println("Usage: StandaloneExecutorBackend <driverUrl> <executorId> <hostname> <cores>")
+    if (!(args.length >= 4)) {
+      //the reason we allow the last frameworkId argument is to make it easy to kill rogue executors
+      System.err.println("Usage: StandaloneExecutorBackend <driverUrl> <executorId> <hostname> <cores> [<frameworkid>]")
       System.exit(1)
     }
     run(args(0), args(1), args(2), args(3).toInt)

--- a/core/src/main/scala/spark/executor/StandaloneExecutorBackend.scala
+++ b/core/src/main/scala/spark/executor/StandaloneExecutorBackend.scala
@@ -68,9 +68,9 @@ private[spark] object StandaloneExecutorBackend {
   }
 
   def main(args: Array[String]) {
-    if (!(args.length >= 4)) {
+    if (args.length < 4) {
       //the reason we allow the last frameworkId argument is to make it easy to kill rogue executors
-      System.err.println("Usage: StandaloneExecutorBackend <driverUrl> <executorId> <hostname> <cores> [<frameworkid>]")
+      System.err.println("Usage: StandaloneExecutorBackend <driverUrl> <executorId> <hostname> <cores> [<appid>]")
       System.exit(1)
     }
     run(args(0), args(1), args(2), args(3).toInt)


### PR DESCRIPTION
For whatever reasons, we've observed that sometimes the StandaloneExecutorBackend process doesn't die when a spark context finishes.  Obviously we'd like to eliminate that from happening in the first place, but in the meantime we just need an automated way to kill these rogue processes.

If the command line args include the jobid for each StandaloneExecutorBackend, then we can use `jps` to find the jobid of all the executors, and filter out those that the master doesn't know about.
