### PR TITLE
Don't call System.exit over uncaught exceptions from shutdown hooks

### DIFF
--- a/core/src/main/scala/spark/storage/DiskStore.scala
+++ b/core/src/main/scala/spark/storage/DiskStore.scala
@@ -178,7 +178,11 @@ private class DiskStore(blockManager: BlockManager, rootDirs: String)
     Runtime.getRuntime.addShutdownHook(new Thread("delete Spark local dirs") {
       override def run() {
         logDebug("Shutdown hook called")
-        localDirs.foreach(localDir => Utils.deleteRecursively(localDir))
+        try {
+          localDirs.foreach(localDir => Utils.deleteRecursively(localDir))
+        } catch {
+          case t: Throwable => logError("Exception while deleting local spark dirs", t)
+        }
       }
     })
   }


### PR DESCRIPTION
Currently, spark.executor.Executor's uncaught exception handler always tries to call System.exit(). Unfortunately, calling System.exit() from a shutdown hook deadlocks. This patch modifies the uncaught exception handler to avoid calling System.exit() when a shutdown is in progress.

This also modifies the delete local directories shutdown hook to catch and log exceptions, which is how I noticed the deadlock.
