### PR TITLE
mapWith, flatMapWith and filterWith

### DIFF
--- a/core/src/main/scala/spark/RDD.scala
+++ b/core/src/main/scala/spark/RDD.scala
@@ -366,7 +366,7 @@ abstract class RDD[T: ClassManifest](
 
   /**
    * Maps f over this RDD, where f takes an additional parameter of type A.  This
-   * additional parameter is produced by constructorOfA, which is called in each
+   * additional parameter is produced by constructA, which is called in each
    * partition with the index of that partition.
    */
   def mapWith[A: ClassManifest, U: ClassManifest](constructA: Int => A, preservesPartitioning: Boolean = false)
@@ -380,7 +380,7 @@ abstract class RDD[T: ClassManifest](
 
   /**
    * FlatMaps f over this RDD, where f takes an additional parameter of type A.  This
-   * additional parameter is produced by constructorOfA, which is called in each
+   * additional parameter is produced by constructA, which is called in each
    * partition with the index of that partition.
    */
   def flatMapWith[A: ClassManifest, U: ClassManifest](constructA: Int => A, preservesPartitioning: Boolean = false)
@@ -394,7 +394,7 @@ abstract class RDD[T: ClassManifest](
 
   /**
    * Applies f to each element of this RDD, where f takes an additional parameter of type A.
-   * This additional parameter is produced by constructorOfA, which is called in each
+   * This additional parameter is produced by constructA, which is called in each
    * partition with the index of that partition.
    */
   def foreachWith[A: ClassManifest](constructA: Int => A)
@@ -408,7 +408,7 @@ abstract class RDD[T: ClassManifest](
 
   /**
    * Filters this RDD with p, where p takes an additional parameter of type A.  This
-   * additional parameter is produced by constructorOfA, which is called in each
+   * additional parameter is produced by constructA, which is called in each
    * partition with the index of that partition.
    */
   def filterWith[A: ClassManifest](constructA: Int => A)

--- a/core/src/main/scala/spark/RDD.scala
+++ b/core/src/main/scala/spark/RDD.scala
@@ -380,7 +380,7 @@ abstract class RDD[T: ClassManifest](
         val factory = factoryBuilder(index, factorySeed)
         iter.map(t => f(factory(t), t))
       }
-      new MapPartitionsWithIndexRDD(this, sc.clean(iterF _), preservesPartitioning)
+    new MapPartitionsWithIndexRDD(this, sc.clean(iterF _), preservesPartitioning)
   }
 
   /**
@@ -391,14 +391,14 @@ abstract class RDD[T: ClassManifest](
    * and a seed value of type B.
    */
   def flatMapWith[A: ClassManifest, B: ClassManifest, U: ClassManifest](
-                                                                     f:(A, T) => Seq[U],
-                                                                     factoryBuilder: (Int, B) => (T => A),
-                                                                     factorySeed: B,
-                                                                     preservesPartitioning: Boolean = false): RDD[U] = {
-    def iterF(index: Int, iter: Iterator[T]): Iterator[U] = {
-      val factory = factoryBuilder(index, factorySeed)
-      iter.flatMap(t => f(factory(t), t))
-    }
+    f:(A, T) => Seq[U],
+    factoryBuilder: (Int, B) => (T => A),
+    factorySeed: B,
+    preservesPartitioning: Boolean = false): RDD[U] = {
+      def iterF(index: Int, iter: Iterator[T]): Iterator[U] = {
+        val factory = factoryBuilder(index, factorySeed)
+        iter.flatMap(t => f(factory(t), t))
+      }
     new MapPartitionsWithIndexRDD(this, sc.clean(iterF _), preservesPartitioning)
   }
 
@@ -418,7 +418,7 @@ abstract class RDD[T: ClassManifest](
         val factory = factoryBuilder(index, factorySeed)
         iter.filter(t => p(factory(t), t))
       }
-      new MapPartitionsWithIndexRDD(this, sc.clean(iterF _), preservesPartitioning)
+    new MapPartitionsWithIndexRDD(this, sc.clean(iterF _), preservesPartitioning)
   }
 
   /**

--- a/core/src/main/scala/spark/RDD.scala
+++ b/core/src/main/scala/spark/RDD.scala
@@ -372,10 +372,10 @@ abstract class RDD[T: ClassManifest](
    * and a seed value of type B.
    */
   def mapWith[A: ClassManifest, B: ClassManifest, U: ClassManifest](
-    f:(A, T) => U,
     factoryBuilder: (Int, B) => (T => A),
     factorySeed: B,
-    preservesPartitioning: Boolean = false): RDD[U] = {
+    preservesPartitioning: Boolean = false)
+    (f:(A, T) => U): RDD[U] = {
       def iterF(index: Int, iter: Iterator[T]): Iterator[U] = {
         val factory = factoryBuilder(index, factorySeed)
         iter.map(t => f(factory(t), t))
@@ -391,10 +391,10 @@ abstract class RDD[T: ClassManifest](
    * and a seed value of type B.
    */
   def flatMapWith[A: ClassManifest, B: ClassManifest, U: ClassManifest](
-    f:(A, T) => Seq[U],
     factoryBuilder: (Int, B) => (T => A),
     factorySeed: B,
-    preservesPartitioning: Boolean = false): RDD[U] = {
+    preservesPartitioning: Boolean = false)
+    (f:(A, T) => Seq[U]): RDD[U] = {
       def iterF(index: Int, iter: Iterator[T]): Iterator[U] = {
         val factory = factoryBuilder(index, factorySeed)
         iter.flatMap(t => f(factory(t), t))
@@ -410,10 +410,10 @@ abstract class RDD[T: ClassManifest](
    * and a seed value of type B.
    */
   def filterWith[A: ClassManifest, B: ClassManifest](
-    p:(A, T) => Boolean,
     factoryBuilder: (Int, B) => (T => A),
     factorySeed: B,
-    preservesPartitioning: Boolean = false): RDD[T] = {
+    preservesPartitioning: Boolean = false)
+    (p:(A, T) => Boolean): RDD[T] = {
       def iterF(index: Int, iter: Iterator[T]): Iterator[T] = {
         val factory = factoryBuilder(index, factorySeed)
         iter.filter(t => p(factory(t), t))

--- a/core/src/main/scala/spark/RDD.scala
+++ b/core/src/main/scala/spark/RDD.scala
@@ -365,6 +365,63 @@ abstract class RDD[T: ClassManifest](
     new MapPartitionsWithIndexRDD(this, sc.clean(f), preservesPartitioning)
 
   /**
+   * Maps f over this RDD where f takes an additional parameter of type A.  This
+   * additional parameter is produced by a factory method T => A which is called
+   * on each invocation of f.  This factory method is produced by the factoryBuilder,
+   * an instance of which is constructed in each partition from the partition index
+   * and a seed value of type B.
+   */
+  def mapWith[A: ClassManifest, B: ClassManifest, U: ClassManifest](
+    f:(A, T) => U,
+    factoryBuilder: (Int, B) => (T => A),
+    factorySeed: B,
+    preservesPartitioning: Boolean = false): RDD[U] = {
+      def iterF(index: Int, iter: Iterator[T]): Iterator[U] = {
+        val factory = factoryBuilder(index, factorySeed)
+        iter.map(t => f(factory(t), t))
+      }
+      new MapPartitionsWithIndexRDD(this, sc.clean(iterF _), preservesPartitioning)
+  }
+
+  /**
+   * FlatMaps f over this RDD where f takes an additional parameter of type A.  This
+   * additional parameter is produced by a factory method T => A which is called
+   * on each invocation of f.  This factory method is produced by the factoryBuilder,
+   * an instance of which is constructed in each partition from the partition index
+   * and a seed value of type B.
+   */
+  def flatMapWith[A: ClassManifest, B: ClassManifest, U: ClassManifest](
+                                                                     f:(A, T) => Seq[U],
+                                                                     factoryBuilder: (Int, B) => (T => A),
+                                                                     factorySeed: B,
+                                                                     preservesPartitioning: Boolean = false): RDD[U] = {
+    def iterF(index: Int, iter: Iterator[T]): Iterator[U] = {
+      val factory = factoryBuilder(index, factorySeed)
+      iter.flatMap(t => f(factory(t), t))
+    }
+    new MapPartitionsWithIndexRDD(this, sc.clean(iterF _), preservesPartitioning)
+  }
+
+  /**
+   * Filters this RDD with p, where p takes an additional parameter of type A.  This
+   * additional parameter is produced by a factory method T => A which is called
+   * on each invocation of p.  This factory method is produced by the factoryBuilder,
+   * an instance of which is constructed in each partition from the partition index
+   * and a seed value of type B.
+   */
+  def filterWith[A: ClassManifest, B: ClassManifest](
+    p:(A, T) => Boolean,
+    factoryBuilder: (Int, B) => (T => A),
+    factorySeed: B,
+    preservesPartitioning: Boolean = false): RDD[T] = {
+      def iterF(index: Int, iter: Iterator[T]): Iterator[T] = {
+        val factory = factoryBuilder(index, factorySeed)
+        iter.filter(t => p(factory(t), t))
+      }
+      new MapPartitionsWithIndexRDD(this, sc.clean(iterF _), preservesPartitioning)
+  }
+
+  /**
    * Zips this RDD with another one, returning key-value pairs with the first element in each RDD,
    * second element in each RDD, etc. Assumes that the two RDDs have the *same number of
    * partitions* and the *same number of elements in each partition* (e.g. one was made through
@@ -404,7 +461,7 @@ abstract class RDD[T: ClassManifest](
 
   /**
    * Return an RDD with the elements from `this` that are not in `other`.
-   * 
+   *
    * Uses `this` partitioner/partition size, because even if `other` is huge, the resulting
    * RDD will be <= us.
    */

--- a/core/src/main/scala/spark/RDD.scala
+++ b/core/src/main/scala/spark/RDD.scala
@@ -365,7 +365,7 @@ abstract class RDD[T: ClassManifest](
     new MapPartitionsWithIndexRDD(this, sc.clean(f), preservesPartitioning)
 
   /**
-   * Maps f over this RDD where, f takes an additional parameter of type A.  This
+   * Maps f over this RDD, where f takes an additional parameter of type A.  This
    * additional parameter is produced by constructorOfA, which is called in each
    * partition with the index of that partition.
    */

--- a/core/src/main/scala/spark/RDD.scala
+++ b/core/src/main/scala/spark/RDD.scala
@@ -369,25 +369,25 @@ abstract class RDD[T: ClassManifest](
    * additional parameter is produced by constructorOfA, which is called in each
    * partition with the index of that partition.
    */
-  def mapWith[A: ClassManifest, U: ClassManifest](constructorOfA: Int => A, preservesPartitioning: Boolean = false)
-    (f:(A, T) => U): RDD[U] = {
+  def mapWith[A: ClassManifest, U: ClassManifest](constructA: Int => A, preservesPartitioning: Boolean = false)
+    (f:(T, A) => U): RDD[U] = {
       def iterF(index: Int, iter: Iterator[T]): Iterator[U] = {
-        val a = constructorOfA(index)
-        iter.map(t => f(a, t))
+        val a = constructA(index)
+        iter.map(t => f(t, a))
       }
     new MapPartitionsWithIndexRDD(this, sc.clean(iterF _), preservesPartitioning)
   }
 
-    /**
+  /**
    * FlatMaps f over this RDD, where f takes an additional parameter of type A.  This
    * additional parameter is produced by constructorOfA, which is called in each
    * partition with the index of that partition.
    */
-  def flatMapWith[A: ClassManifest, U: ClassManifest](constructorOfA: Int => A, preservesPartitioning: Boolean = false)
-    (f:(A, T) => Seq[U]): RDD[U] = {
+  def flatMapWith[A: ClassManifest, U: ClassManifest](constructA: Int => A, preservesPartitioning: Boolean = false)
+    (f:(T, A) => Seq[U]): RDD[U] = {
       def iterF(index: Int, iter: Iterator[T]): Iterator[U] = {
-        val a = constructorOfA(index)
-        iter.flatMap(t => f(a, t))
+        val a = constructA(index)
+        iter.flatMap(t => f(t, a))
       }
     new MapPartitionsWithIndexRDD(this, sc.clean(iterF _), preservesPartitioning)
   }
@@ -397,11 +397,11 @@ abstract class RDD[T: ClassManifest](
    * This additional parameter is produced by constructorOfA, which is called in each
    * partition with the index of that partition.
    */
-  def foreachWith[A: ClassManifest](constructorOfA: Int => A)
-    (f:(A, T) => Unit) {
+  def foreachWith[A: ClassManifest](constructA: Int => A)
+    (f:(T, A) => Unit) {
       def iterF(index: Int, iter: Iterator[T]): Iterator[T] = {
-        val a = constructorOfA(index)
-        iter.map(t => {f(a, t); t})
+        val a = constructA(index)
+        iter.map(t => {f(t, a); t})
       }
     (new MapPartitionsWithIndexRDD(this, sc.clean(iterF _), true)).foreach(_ => {})
   }
@@ -411,11 +411,11 @@ abstract class RDD[T: ClassManifest](
    * additional parameter is produced by constructorOfA, which is called in each
    * partition with the index of that partition.
    */
-  def filterWith[A: ClassManifest](constructorOfA: Int => A)
-    (p:(A, T) => Boolean): RDD[T] = {
+  def filterWith[A: ClassManifest](constructA: Int => A)
+    (p:(T, A) => Boolean): RDD[T] = {
       def iterF(index: Int, iter: Iterator[T]): Iterator[T] = {
-        val a = constructorOfA(index)
-        iter.filter(t => p(a, t))
+        val a = constructA(index)
+        iter.filter(t => p(t, a))
       }
     new MapPartitionsWithIndexRDD(this, sc.clean(iterF _), true)
   }

--- a/core/src/test/scala/spark/RDDSuite.scala
+++ b/core/src/test/scala/spark/RDDSuite.scala
@@ -185,8 +185,8 @@ class RDDSuite extends FunSuite with LocalSparkContext {
     val randoms = ones.mapWith(
       (random: Double, t: Int) => random * t,
       (index: Int, seed: Int) => {
-	val prng = new java.util.Random(index + seed)
-	(_ => prng.nextDouble)},
+	      val prng = new java.util.Random(index + seed)
+	      (_ => prng.nextDouble)},
       42).
       collect()
     val prn42_3 = {
@@ -230,16 +230,16 @@ class RDDSuite extends FunSuite with LocalSparkContext {
     val sample = ints.filterWith(
       (random: Int, t: Int) => random == 0,
       (index: Int, seed: Int) => {
-	val prng = new Random(index + seed)
-	(_ => prng.nextInt(3))},
+	      val prng = new Random(index + seed)
+	      (_ => prng.nextInt(3))},
       42).
       collect()
     val checkSample = {
       val prng42 = new Random(42)
       val prng43 = new Random(43)
       Array(1, 2, 3, 4, 5, 6).filter{i =>
-	if (i < 4) 0 == prng42.nextInt(3)
-	else 0 == prng43.nextInt(3)}
+	      if (i < 4) 0 == prng42.nextInt(3)
+	      else 0 == prng43.nextInt(3)}
     }
     assert(sample.size === checkSample.size)
     for (i <- 0 until sample.size) assert(sample(i) === checkSample(i))

--- a/core/src/test/scala/spark/RDDSuite.scala
+++ b/core/src/test/scala/spark/RDDSuite.scala
@@ -185,7 +185,7 @@ class RDDSuite extends FunSuite with LocalSparkContext {
     val ones = sc.makeRDD(Array(1, 1, 1, 1, 1, 1), 2)
     val randoms = ones.mapWith(
       (index: Int) => new Random(index + 42))
-      {(prng: Random, t: Int) => prng.nextDouble * t}.collect()
+      {(t: Int, prng: Random) => prng.nextDouble * t}.collect()
     val prn42_3 = {
       val prng42 = new Random(42)
       prng42.nextDouble(); prng42.nextDouble(); prng42.nextDouble()
@@ -204,7 +204,7 @@ class RDDSuite extends FunSuite with LocalSparkContext {
     val ones = sc.makeRDD(Array(1, 1, 1, 1, 1, 1), 2)
     val randoms = ones.flatMapWith(
       (index: Int) => new Random(index + 42))
-      {(prng: Random, t: Int) =>
+      {(t: Int, prng: Random) =>
         val random = prng.nextDouble()
         Seq(random * t, random * t * 10)}.
       collect()
@@ -226,7 +226,7 @@ class RDDSuite extends FunSuite with LocalSparkContext {
     val ints = sc.makeRDD(Array(1, 2, 3, 4, 5, 6), 2)
     val sample = ints.filterWith(
       (index: Int) => new Random(index + 42))
-      {(prng: Random, t: Int) => prng.nextInt(3) == 0}.
+      {(t: Int, prng: Random) => prng.nextInt(3) == 0}.
       collect()
     val checkSample = {
       val prng42 = new Random(42)

--- a/core/src/test/scala/spark/RDDSuite.scala
+++ b/core/src/test/scala/spark/RDDSuite.scala
@@ -183,11 +183,11 @@ class RDDSuite extends FunSuite with LocalSparkContext {
     sc = new SparkContext("local", "test")
     val ones = sc.makeRDD(Array(1, 1, 1, 1, 1, 1), 2)
     val randoms = ones.mapWith(
-      (random: Double, t: Int) => random * t,
       (index: Int, seed: Int) => {
 	      val prng = new java.util.Random(index + seed)
 	      (_ => prng.nextDouble)},
-      42).
+      42)
+      {(random: Double, t: Int) => random * t}.
       collect()
     val prn42_3 = {
       val prng42 = new java.util.Random(42)
@@ -205,11 +205,11 @@ class RDDSuite extends FunSuite with LocalSparkContext {
     sc = new SparkContext("local", "test")
     val ones = sc.makeRDD(Array(1, 1, 1, 1, 1, 1), 2)
     val randoms = ones.flatMapWith(
-      (random: Double, t: Int) => Seq(random * t, random * t * 10),
       (index: Int, seed: Int) => {
         val prng = new java.util.Random(index + seed)
         (_ => prng.nextDouble)},
-      42).
+      42)
+      {(random: Double, t: Int) => Seq(random * t, random * t * 10)}.
       collect()
     val prn42_3 = {
       val prng42 = new java.util.Random(42)
@@ -228,11 +228,11 @@ class RDDSuite extends FunSuite with LocalSparkContext {
     sc = new SparkContext("local", "test")
     val ints = sc.makeRDD(Array(1, 2, 3, 4, 5, 6), 2)
     val sample = ints.filterWith(
-      (random: Int, t: Int) => random == 0,
       (index: Int, seed: Int) => {
 	      val prng = new Random(index + seed)
 	      (_ => prng.nextInt(3))},
-      42).
+      42)
+      {(random: Int, t: Int) => random == 0}.
       collect()
     val checkSample = {
       val prng42 = new Random(42)

--- a/core/src/test/scala/spark/RDDSuite.scala
+++ b/core/src/test/scala/spark/RDDSuite.scala
@@ -204,9 +204,9 @@ class RDDSuite extends FunSuite with LocalSparkContext {
     val ones = sc.makeRDD(Array(1, 1, 1, 1, 1, 1), 2)
     val randoms = ones.flatMapWith(
       (index: Int) => new Random(index + 42))
-      {(prng: Random, t: Int) => {
+      {(prng: Random, t: Int) =>
         val random = prng.nextDouble()
-        Seq(random * t, random * t * 10)}}.
+        Seq(random * t, random * t * 10)}.
       collect()
     val prn42_3 = {
       val prng42 = new Random(42)

--- a/core/src/test/scala/spark/RDDSuite.scala
+++ b/core/src/test/scala/spark/RDDSuite.scala
@@ -180,21 +180,18 @@ class RDDSuite extends FunSuite with LocalSparkContext {
   }
 
   test("mapWith") {
+    import java.util.Random
     sc = new SparkContext("local", "test")
     val ones = sc.makeRDD(Array(1, 1, 1, 1, 1, 1), 2)
     val randoms = ones.mapWith(
-      (index: Int, seed: Int) => {
-	      val prng = new java.util.Random(index + seed)
-	      (_ => prng.nextDouble)},
-      42)
-      {(random: Double, t: Int) => random * t}.
-      collect()
+      (index: Int) => new Random(index + 42))
+      {(prng: Random, t: Int) => prng.nextDouble * t}.collect()
     val prn42_3 = {
-      val prng42 = new java.util.Random(42)
+      val prng42 = new Random(42)
       prng42.nextDouble(); prng42.nextDouble(); prng42.nextDouble()
     }
     val prn43_3 = {
-      val prng43 = new java.util.Random(43)
+      val prng43 = new Random(43)
       prng43.nextDouble(); prng43.nextDouble(); prng43.nextDouble()
     }
     assert(randoms(2) === prn42_3)
@@ -202,21 +199,21 @@ class RDDSuite extends FunSuite with LocalSparkContext {
   }
 
   test("flatMapWith") {
+    import java.util.Random
     sc = new SparkContext("local", "test")
     val ones = sc.makeRDD(Array(1, 1, 1, 1, 1, 1), 2)
     val randoms = ones.flatMapWith(
-      (index: Int, seed: Int) => {
-        val prng = new java.util.Random(index + seed)
-        (_ => prng.nextDouble)},
-      42)
-      {(random: Double, t: Int) => Seq(random * t, random * t * 10)}.
+      (index: Int) => new Random(index + 42))
+      {(prng: Random, t: Int) => {
+        val random = prng.nextDouble()
+        Seq(random * t, random * t * 10)}}.
       collect()
     val prn42_3 = {
-      val prng42 = new java.util.Random(42)
+      val prng42 = new Random(42)
       prng42.nextDouble(); prng42.nextDouble(); prng42.nextDouble()
     }
     val prn43_3 = {
-      val prng43 = new java.util.Random(43)
+      val prng43 = new Random(43)
       prng43.nextDouble(); prng43.nextDouble(); prng43.nextDouble()
     }
     assert(randoms(5) === prn42_3 * 10)
@@ -228,11 +225,8 @@ class RDDSuite extends FunSuite with LocalSparkContext {
     sc = new SparkContext("local", "test")
     val ints = sc.makeRDD(Array(1, 2, 3, 4, 5, 6), 2)
     val sample = ints.filterWith(
-      (index: Int, seed: Int) => {
-	      val prng = new Random(index + seed)
-	      (_ => prng.nextInt(3))},
-      42)
-      {(random: Int, t: Int) => random == 0}.
+      (index: Int) => new Random(index + 42))
+      {(prng: Random, t: Int) => prng.nextInt(3) == 0}.
       collect()
     val checkSample = {
       val prng42 = new Random(42)

--- a/core/src/test/scala/spark/RDDSuite.scala
+++ b/core/src/test/scala/spark/RDDSuite.scala
@@ -178,4 +178,70 @@ class RDDSuite extends FunSuite with LocalSparkContext {
     assert(prunedData.size === 1)
     assert(prunedData(0) === 10)
   }
+
+  test("mapWith") {
+    sc = new SparkContext("local", "test")
+    val ones = sc.makeRDD(Array(1, 1, 1, 1, 1, 1), 2)
+    val randoms = ones.mapWith(
+      (random: Double, t: Int) => random * t,
+      (index: Int, seed: Int) => {
+	val prng = new java.util.Random(index + seed)
+	(_ => prng.nextDouble)},
+      42).
+      collect()
+    val prn42_3 = {
+      val prng42 = new java.util.Random(42)
+      prng42.nextDouble(); prng42.nextDouble(); prng42.nextDouble()
+    }
+    val prn43_3 = {
+      val prng43 = new java.util.Random(43)
+      prng43.nextDouble(); prng43.nextDouble(); prng43.nextDouble()
+    }
+    assert(randoms(2) === prn42_3)
+    assert(randoms(5) === prn43_3)
+  }
+
+  test("flatMapWith") {
+    sc = new SparkContext("local", "test")
+    val ones = sc.makeRDD(Array(1, 1, 1, 1, 1, 1), 2)
+    val randoms = ones.flatMapWith(
+      (random: Double, t: Int) => Seq(random * t, random * t * 10),
+      (index: Int, seed: Int) => {
+        val prng = new java.util.Random(index + seed)
+        (_ => prng.nextDouble)},
+      42).
+      collect()
+    val prn42_3 = {
+      val prng42 = new java.util.Random(42)
+      prng42.nextDouble(); prng42.nextDouble(); prng42.nextDouble()
+    }
+    val prn43_3 = {
+      val prng43 = new java.util.Random(43)
+      prng43.nextDouble(); prng43.nextDouble(); prng43.nextDouble()
+    }
+    assert(randoms(5) === prn42_3 * 10)
+    assert(randoms(11) === prn43_3 * 10)
+  }
+
+  test("filterWith") {
+    import java.util.Random
+    sc = new SparkContext("local", "test")
+    val ints = sc.makeRDD(Array(1, 2, 3, 4, 5, 6), 2)
+    val sample = ints.filterWith(
+      (random: Int, t: Int) => random == 0,
+      (index: Int, seed: Int) => {
+	val prng = new Random(index + seed)
+	(_ => prng.nextInt(3))},
+      42).
+      collect()
+    val checkSample = {
+      val prng42 = new Random(42)
+      val prng43 = new Random(43)
+      Array(1, 2, 3, 4, 5, 6).filter{i =>
+	if (i < 4) 0 == prng42.nextInt(3)
+	else 0 == prng43.nextInt(3)}
+    }
+    assert(sample.size === checkSample.size)
+    for (i <- 0 until sample.size) assert(sample(i) === checkSample(i))
+  }
 }


### PR DESCRIPTION
A general means to make a per-partition Thing available for use in map, flatMap and filter transformations.

Motivation came from the SparkPi example, where the Thing needed in the map is a way to get a pair of random numbers between -1 and 1.  The example cheats by using scala.math.random, which serializes all the calls within a JVM to the global PRNG.  Trying to avoid that by creating a PRNG val within the map function is an inefficient solution since a new PRNG is constructed for each RDD element, when what is really wanted is a single PRNG resource per partition that will be used for all of the elements in a partition.  It's possible to meet that goal by using mapPartitionsWithIndex, but that requires rethinking map, flatMap and filter in terms of mapping an iterator to an iterator.  The effort in this pull request is an attempt to provide a useful generalization of the per-partition Thing that preserve map, flatMap and filter semantics.

The basic idea is that a Thing-factory function will be available within a map, flatMap or filter function.  That factory function will produce a Thing given an RDD element.  In the motivating case of SparkPi, the Thing to be produced is a pair of random values, and the Thing-factory would simply be a function Int => (Double, Double), where the Doubles are random values between -1 and 1.  In fact, it would only be _ => (Double, Double), since the RDD element is not needed to produce the pair of random values.  In order to setup the Thing-factory for each partition, a factoryBuilder must be provided, which constructs the Thing-factory from the index of the partition and a seed value.

Basic examples using random number generators are in RDDSuite, but PRNGs are by no means the only Thing-makers that could be instantiated with this technique.  I'll post some more examples to the Spark Developers list and see whether that generates some more feedback as to whether this approach is generally useful enough to warrant merging.
