### PR TITLE
Adds choice of persistence level to Bagel.

### DIFF
--- a/bagel/src/main/scala/spark/bagel/Bagel.scala
+++ b/bagel/src/main/scala/spark/bagel/Bagel.scala
@@ -34,7 +34,7 @@ object Bagel extends Logging {
    * @tparam M message type
    * @tparam C combiner
    * @tparam A aggregator
-   * @return a set of (K, V) pairs representing the graph after completion of the program
+   * @return an RDD of (K, V) pairs representing the graph after completion of the program
    */
   def run[K: Manifest, V <: Vertex : Manifest, M <: Message[K] : Manifest,
           C: Manifest, A: Manifest](
@@ -110,8 +110,10 @@ object Bagel extends Logging {
       addAggregatorArg[K, V, M, C](compute))
   }
 
-  /** Runs a Bagel program with no [[spark.bagel.Aggregator]], default [[spark.HashPartitioner]]
-    * and default storage level*/
+  /**
+   * Runs a Bagel program with no [[spark.bagel.Aggregator]], default [[spark.HashPartitioner]]
+   * and default storage level
+   */
   def run[K: Manifest, V <: Vertex : Manifest, M <: Message[K] : Manifest, C: Manifest](
     sc: SparkContext,
     vertices: RDD[(K, V)],
@@ -139,8 +141,10 @@ object Bagel extends Logging {
       addAggregatorArg[K, V, M, C](compute))
   }
 
-  /** Runs a Bagel program with no [[spark.bagel.Aggregator]], default [[spark.HashPartitioner]],
-    * [[spark.bagel.DefaultCombiner]] and the default storage level */
+  /**
+   * Runs a Bagel program with no [[spark.bagel.Aggregator]], default [[spark.HashPartitioner]],
+   * [[spark.bagel.DefaultCombiner]] and the default storage level
+   */
   def run[K: Manifest, V <: Vertex : Manifest, M <: Message[K] : Manifest](
     sc: SparkContext,
     vertices: RDD[(K, V)],
@@ -150,8 +154,10 @@ object Bagel extends Logging {
     compute: (V, Option[Array[M]], Int) => (V, Array[M])
   ): RDD[(K, V)] = run(sc, vertices, messages, numPartitions, DEFAULT_STORAGE_LEVEL)(compute)
 
-  /** Runs a Bagel program with no [[spark.bagel.Aggregator]], the default [[spark.HashPartitioner]]
-    * and [[spark.bagel.DefaultCombiner]]*/
+  /**
+   * Runs a Bagel program with no [[spark.bagel.Aggregator]], the default [[spark.HashPartitioner]]
+   * and [[spark.bagel.DefaultCombiner]]
+   */
   def run[K: Manifest, V <: Vertex : Manifest, M <: Message[K] : Manifest](
     sc: SparkContext,
     vertices: RDD[(K, V)],

--- a/bagel/src/test/scala/bagel/BagelSuite.scala
+++ b/bagel/src/test/scala/bagel/BagelSuite.scala
@@ -7,6 +7,7 @@ import org.scalatest.time.SpanSugar._
 import scala.collection.mutable.ArrayBuffer
 
 import spark._
+import storage.StorageLevel
 
 class TestVertex(val active: Boolean, val age: Int) extends Vertex with Serializable
 class TestMessage(val targetId: String) extends Message[String] with Serializable
@@ -71,6 +72,23 @@ class BagelSuite extends FunSuite with Assertions with BeforeAndAfter with Timeo
       val numSupersteps = 50
       val result =
         Bagel.run(sc, verts, msgs, sc.defaultParallelism) {
+          (self: TestVertex, msgs: Option[Array[TestMessage]], superstep: Int) =>
+            (new TestVertex(superstep < numSupersteps - 1, self.age + 1), Array[TestMessage]())
+        }
+      for ((id, vert) <- result.collect) {
+        assert(vert.age === numSupersteps)
+      }
+    }
+  }
+
+  test("using non-default persistence level") {
+    failAfter(10 seconds) {
+      sc = new SparkContext("local", "test")
+      val verts = sc.parallelize((1 to 4).map(id => (id.toString, new TestVertex(true, 0))))
+      val msgs = sc.parallelize(Array[(String, TestMessage)]())
+      val numSupersteps = 50
+      val result =
+        Bagel.run(sc, verts, msgs, sc.defaultParallelism, StorageLevel.DISK_ONLY) {
           (self: TestVertex, msgs: Option[Array[TestMessage]], superstep: Int) =>
             (new TestVertex(superstep < numSupersteps - 1, self.age + 1), Array[TestMessage]())
         }


### PR DESCRIPTION
This PR adds support for selecting the `StorageLevel` to use when running a Bagel computation. The default remains `MEMORY_ONLY` and should be fully backward-compatible in terms of `run` method calls.

Note that due to the way Scala handles default arguments it was not possible to simply add the `storageLevel` parameter to each `run` method with a default. Hence I did so for the "main" `run` method and then added a second method for each of the remaining ones, that takes care of the default argument (and whose signature matches the old versions).

See https://groups.google.com/forum/?fromgroups=#!topic/spark-developers/F_UOsKM8ZEM for the discussion.

I also added some documentation and a (probably superfluous) test to the `BagelSuite` to test use of the non-default `StorageLevel` parameter.
