### PR TITLE
Send block sizes as longs in BlockManager updates

### DIFF
--- a/core/src/main/scala/spark/storage/BlockManagerMessages.scala
+++ b/core/src/main/scala/spark/storage/BlockManagerMessages.scala
@@ -49,16 +49,16 @@ class UpdateBlockInfo(
     blockManagerId.writeExternal(out)
     out.writeUTF(blockId)
     storageLevel.writeExternal(out)
-    out.writeInt(memSize.toInt)
-    out.writeInt(diskSize.toInt)
+    out.writeLong(memSize)
+    out.writeLong(diskSize)
   }
 
   override def readExternal(in: ObjectInput) {
     blockManagerId = BlockManagerId(in)
     blockId = in.readUTF()
     storageLevel = StorageLevel(in)
-    memSize = in.readInt()
-    diskSize = in.readInt()
+    memSize = in.readLong()
+    diskSize = in.readLong()
   }
 }
 


### PR DESCRIPTION
Currently, UpdateBlockMessage stores the sizes of blocks (in memory and on disk) as longs but serializes them as ints, silently truncating the values. This means that blocks which are larger (or estimated larger) than 2G are accounted for incorrectly, which can result in the master thinking a block manager has more memory free than its capacity. 

This patch serializes UpdateBlockMessage sizes as longs.

I assume that the sizes were serialized as ints for some reason, in which case this may create a regression. (I suspect that there are other problems with blocks >2G, e.g. it may not be possible to persist them at MEMORY_ONLY_SER, but these should at least not be silent problems.)
