### PR TITLE
Remove try/catch block that can't be hit.

### DIFF
--- a/core/src/main/scala/spark/deploy/worker/Worker.scala
+++ b/core/src/main/scala/spark/deploy/worker/Worker.scala
@@ -74,16 +74,10 @@ private[spark] class Worker(
 
   def connectToMaster() {
     logInfo("Connecting to master " + masterUrl)
-    try {
-      master = context.actorFor(Master.toAkkaUrl(masterUrl))
-      master ! RegisterWorker(workerId, ip, port, cores, memory, webUiPort, publicAddress)
-      context.system.eventStream.subscribe(self, classOf[RemoteClientLifeCycleEvent])
-      context.watch(master) // Doesn't work with remote actors, but useful for testing
-    } catch {
-      case e: Exception =>
-        logError("Failed to connect to master", e)
-        System.exit(1)
-    }
+    master = context.actorFor(Master.toAkkaUrl(masterUrl))
+    master ! RegisterWorker(workerId, ip, port, cores, memory, webUiPort, publicAddress)
+    context.system.eventStream.subscribe(self, classOf[RemoteClientLifeCycleEvent])
+    context.watch(master) // Doesn't work with remote actors, but useful for testing
   }
 
   def startWebUi() {


### PR DESCRIPTION
Minor change, but like the code from the StandaloneExecutorBackend.preStart that was fixed a few weeks ago, all of these method calls are async, and so will not cause connection/etc. exceptions.

Granted, this is not causing any bugs, but it can lure the programmer into thinking the calls are sync (it did me anyway) and so lead to seemingly-surprising behavior.

It seems simpler to just take it out, so it mirrors what StandaloneExecutorBackend.preStart looks like now.
