### PR TITLE
Shutdown StandaloneExecutorBackend properly in non-error case by sending...

### DIFF
--- a/core/src/main/scala/spark/executor/StandaloneExecutorBackend.scala
+++ b/core/src/main/scala/spark/executor/StandaloneExecutorBackend.scala
@@ -4,7 +4,7 @@ import java.nio.ByteBuffer
 import spark.Logging
 import spark.TaskState.TaskState
 import spark.util.AkkaUtils
-import akka.actor.{ActorRef, Actor, Props, Terminated}
+import akka.actor.{ActorRef, Actor, ActorSystem, Props, Terminated}
 import akka.remote.{RemoteClientLifeCycleEvent, RemoteClientShutdown, RemoteClientDisconnected}
 import java.util.concurrent.{TimeUnit, ThreadPoolExecutor, SynchronousQueue}
 import spark.scheduler.cluster._
@@ -12,13 +12,15 @@ import spark.scheduler.cluster.RegisteredExecutor
 import spark.scheduler.cluster.LaunchTask
 import spark.scheduler.cluster.RegisterExecutorFailed
 import spark.scheduler.cluster.RegisterExecutor
+import spark.scheduler.cluster.StopExecutor
 
 private[spark] class StandaloneExecutorBackend(
     executor: Executor,
     driverUrl: String,
     executorId: String,
     hostname: String,
-    cores: Int)
+    cores: Int,
+    actorSystem: ActorSystem)
   extends Actor
   with ExecutorBackend
   with Logging {
@@ -45,6 +47,12 @@ private[spark] class StandaloneExecutorBackend(
     case LaunchTask(taskDesc) =>
       logInfo("Got assigned task " + taskDesc.taskId)
       executor.launchTask(this, taskDesc.taskId, taskDesc.serializedTask)
+      
+    case StopExecutor =>
+      sender ! true
+      actorSystem.shutdown()
+      context.stop(self)
+      System.exit(0)
 
     case Terminated(_) | RemoteClientDisconnected(_, _) | RemoteClientShutdown(_, _) =>
       logError("Driver terminated or disconnected! Shutting down.")
@@ -62,7 +70,7 @@ private[spark] object StandaloneExecutorBackend {
     // before getting started with all our system properties, etc
     val (actorSystem, boundPort) = AkkaUtils.createActorSystem("sparkExecutor", hostname, 0)
     val actor = actorSystem.actorOf(
-      Props(new StandaloneExecutorBackend(new Executor, driverUrl, executorId, hostname, cores)),
+      Props(new StandaloneExecutorBackend(new Executor, driverUrl, executorId, hostname, cores, actorSystem)),
       name = "Executor")
     actorSystem.awaitTermination()
   }

--- a/core/src/main/scala/spark/scheduler/cluster/StandaloneClusterMessage.scala
+++ b/core/src/main/scala/spark/scheduler/cluster/StandaloneClusterMessage.scala
@@ -17,6 +17,9 @@ case class RegisteredExecutor(sparkProperties: Seq[(String, String)])
 private[spark]
 case class RegisterExecutorFailed(message: String) extends StandaloneClusterMessage
 
+private[spark]
+case object StopExecutor extends StandaloneClusterMessage
+
 // Executors to driver
 private[spark]
 case class RegisterExecutor(executorId: String, host: String, cores: Int)


### PR DESCRIPTION
... a termination message instead of calling process.destroy.

This gives the executor process the chance to properly clean up after itself. E.g. spark.Utils.createTempDir() registers a JVM shutdown hook per created dir. These get never executed if we terminate the executor via process.destroy, so I think sending a termination message is the nicer way, at least in the good case. In an error case - e.g. the executor not reacting anymore - we can still stick with the destroy method.
