### PR TITLE
Bumping version for Twitter Algebird to latest

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>algebird-core_2.9.2</artifactId>
-      <version>0.1.8</version>
+      <version>0.1.11</version>
     </dependency>
     <dependency>
       <groupId>org.scalatest</groupId>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -157,7 +157,7 @@ object SparkBuild extends Build {
 
   def examplesSettings = sharedSettings ++ Seq(
     name := "spark-examples",
-    libraryDependencies ++= Seq("com.twitter" % "algebird-core_2.9.2" % "0.1.8")
+    libraryDependencies ++= Seq("com.twitter" % "algebird-core_2.9.2" % "0.1.11")
   )
 
   def bagelSettings = sharedSettings ++ Seq(name := "spark-bagel")


### PR DESCRIPTION
Originally when I included Algebird in the examples project, the latest version didn't target JDK 6, hence we went back to 0.1.8.

In https://github.com/twitter/algebird/pull/137 this is fixed so we can bump the version up.

This is nice since the latest Algebird has some other useful stuff like TopK counting via PriorityQueues, for example.
