### PR TITLE
Don't pull in old versions of Jackson via hadoop-core

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -129,7 +129,7 @@ object SparkBuild extends Build {
       "org.slf4j" % "slf4j-api" % slf4jVersion,
       "org.slf4j" % "slf4j-log4j12" % slf4jVersion,
       "com.ning" % "compress-lzf" % "0.8.4",
-      "org.apache.hadoop" % "hadoop-core" % HADOOP_VERSION,
+      "org.apache.hadoop" % "hadoop-core" % HADOOP_VERSION excludeAll( ExclusionRule(organization = "org.codehaus.jackson") ),
       "asm" % "asm-all" % "3.3.1",
       "com.google.protobuf" % "protobuf-java" % "2.4.1",
       "de.javakaffee" % "kryo-serializers" % "0.22",


### PR DESCRIPTION
This patch fixes a problem where a conflicting older version of `jackson-core-asl` and `jackson-mapper-asl` were added to the `lib_managed` directory in addition to a newer version.  This causes problems when using a Hadoop InputFormat that uses the jackson libraries, as the 1.0.1 version was being loaded before the 1.9.3 version and overriding it.

After applying this patch, only the later version of the jackson libraries remains on the lib_managed directory, as shown below:

``` bash
$ git checkout master
$ sbt/sbt package
...
$ find . -name '*jackson*jar'
./lib_managed/jars/jackson-core-asl-1.0.1.jar
./lib_managed/jars/jackson-core-asl-1.9.3.jar
./lib_managed/jars/jackson-mapper-asl-1.0.1.jar
./lib_managed/jars/jackson-mapper-asl-1.9.3.jar
$ git checkout patch-jackson-conflict
$ sbt/sbt package
...
$ find . -name '*jackson*jar'
./lib_managed/jars/jackson-core-asl-1.9.3.jar
./lib_managed/jars/jackson-mapper-asl-1.9.3.jar
$
```
