### PR TITLE
Fix committing problem when saving as text file on hdfs 

### DIFF
--- a/core/src/main/scala/spark/HadoopWriter.scala
+++ b/core/src/main/scala/spark/HadoopWriter.scala
@@ -94,7 +94,7 @@ class HadoopWriter(@transient jobConf: JobConf) extends Logging with Serializabl
     if (cmtr.needsTaskCommit(taCtxt)) {
       try {
         cmtr.commitTask(taCtxt)
-	cmtr.commitJob(jobCtxt)
+	    cmtr.commitJob(jobCtxt)
         logInfo (taID + ": Committed")
       } catch {
         case e: IOException => { 

--- a/core/src/main/scala/spark/HadoopWriter.scala
+++ b/core/src/main/scala/spark/HadoopWriter.scala
@@ -89,10 +89,12 @@ class HadoopWriter(@transient jobConf: JobConf) extends Logging with Serializabl
 
   def commit() {
     val taCtxt = getTaskContext()
+    val jobCtxt = getJobContext()
     val cmtr = getOutputCommitter() 
     if (cmtr.needsTaskCommit(taCtxt)) {
       try {
         cmtr.commitTask(taCtxt)
+	cmtr.commitJob(jobCtxt)
         logInfo (taID + ": Committed")
       } catch {
         case e: IOException => { 

--- a/core/src/main/scala/spark/PairRDDFunctions.scala
+++ b/core/src/main/scala/spark/PairRDDFunctions.scala
@@ -519,6 +519,7 @@ class PairRDDFunctions[K: ClassManifest, V: ClassManifest](
       }
       writer.close(hadoopContext)
       committer.commitTask(hadoopContext)
+      committer.commitJob(hadoopContext)
       return 1
     }
     val jobFormat = outputFormatClass.newInstance

--- a/core/src/main/scala/spark/RDD.scala
+++ b/core/src/main/scala/spark/RDD.scala
@@ -480,7 +480,9 @@ abstract class RDD[T: ClassManifest](@transient sc: SparkContext) extends Serial
    */
   def saveAsTextFile(path: String) {
     this.map(x => (NullWritable.get(), new Text(x.toString)))
-      .saveAsNewAPIHadoopFile[NewTextOutputFormat[NullWritable, Text]](path)
+      .saveAsHadoopFile[TextOutputFormat[NullWritable, Text]](path)
+      //or call new API with:
+      //.saveAsNewAPIHadoopFile[NewTextOutputFormat[NullWritable, Text]](path)
   }
 
   /**

--- a/core/src/main/scala/spark/RDD.scala
+++ b/core/src/main/scala/spark/RDD.scala
@@ -25,6 +25,8 @@ import org.apache.hadoop.mapred.OutputFormat
 import org.apache.hadoop.mapred.SequenceFileOutputFormat
 import org.apache.hadoop.mapred.TextOutputFormat
 
+import org.apache.hadoop.mapreduce.lib.output.{TextOutputFormat => NewTextOutputFormat} 
+
 import it.unimi.dsi.fastutil.objects.{Object2LongOpenHashMap => OLMap}
 
 import spark.partial.BoundedDouble
@@ -478,7 +480,7 @@ abstract class RDD[T: ClassManifest](@transient sc: SparkContext) extends Serial
    */
   def saveAsTextFile(path: String) {
     this.map(x => (NullWritable.get(), new Text(x.toString)))
-      .saveAsHadoopFile[TextOutputFormat[NullWritable, Text]](path)
+      .saveAsNewAPIHadoopFile[NewTextOutputFormat[NullWritable, Text]](path)
   }
 
   /**

--- a/examples/src/main/scala/spark/examples/SparkPi.scala
+++ b/examples/src/main/scala/spark/examples/SparkPi.scala
@@ -4,6 +4,9 @@ import scala.math.random
 import spark._
 import SparkContext._
 
+import org.apache.hadoop.conf.Configuration
+
+
 object SparkPi {
   def main(args: Array[String]) {
     if (args.length == 0) {
@@ -19,7 +22,8 @@ object SparkPi {
       if (x*x + y*y < 1) 1 else 0
     }.reduce(_ + _)
     println("Pi is roughly " + 4.0 * count / n)
-    spark.makeRDD(List("Pi is roughly " + 4.0 * count / n), 1).saveAsTextFile("hdfs://localhost/tmp/pi")
+    val namenode =  new Configuration().get("fs.default.name")
+    spark.makeRDD(List("Pi is roughly " + 4.0 * count / n), 1).saveAsTextFile(namenode + "/tmp/pi")
     spark.stop()
   }
 }

--- a/examples/src/main/scala/spark/examples/SparkPi.scala
+++ b/examples/src/main/scala/spark/examples/SparkPi.scala
@@ -4,9 +4,6 @@ import scala.math.random
 import spark._
 import SparkContext._
 
-import org.apache.hadoop.conf.Configuration
-
-
 object SparkPi {
   def main(args: Array[String]) {
     if (args.length == 0) {
@@ -22,8 +19,6 @@ object SparkPi {
       if (x*x + y*y < 1) 1 else 0
     }.reduce(_ + _)
     println("Pi is roughly " + 4.0 * count / n)
-    val namenode =  new Configuration().get("fs.default.name")
-    spark.makeRDD(List("Pi is roughly " + 4.0 * count / n), 1).saveAsTextFile(namenode + "/tmp/pi")
     spark.stop()
   }
 }

--- a/examples/src/main/scala/spark/examples/SparkPi.scala
+++ b/examples/src/main/scala/spark/examples/SparkPi.scala
@@ -19,6 +19,7 @@ object SparkPi {
       if (x*x + y*y < 1) 1 else 0
     }.reduce(_ + _)
     println("Pi is roughly " + 4.0 * count / n)
+    spark.makeRDD(List("Pi is roughly " + 4.0 * count / n), 1).saveAsTextFile("hdfs://localhost/tmp/pi")
     spark.stop()
   }
 }

--- a/examples/src/main/scala/spark/examples/SparkSaveText.scala
+++ b/examples/src/main/scala/spark/examples/SparkSaveText.scala
@@ -1,0 +1,21 @@
+package spark.examples
+
+import spark._
+import SparkContext._
+
+import org.apache.hadoop.conf.Configuration
+
+
+object SparkSaveText {
+  def main(args: Array[String]) {
+    val spark = new SparkContext(args(0), "SparkSaveText")
+    val numbers = spark.parallelize(1 to 100)
+    val namenode =  new Configuration().get("fs.default.name")
+
+    numbers.saveAsTextFile(namenode + "/user/hduser/numbers")
+
+    spark.makeRDD(List("Pi is 3.14 "), 1).saveAsTextFile(namenode + "/user/hduser/pi")
+
+    spark.stop()
+  }
+}

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -9,7 +9,7 @@ import twirl.sbt.TwirlPlugin._
 
 object SparkBuild extends Build {
   // Hadoop version to build against. For the YARN branch, this needs to support YARN.
-  val HADOOP_VERSION = "2.0.1-alpha"
+  val HADOOP_VERSION = "2.0.3-alpha"
 
   lazy val root = Project("root", file("."), settings = rootSettings) aggregate(core, repl, examples, bagel)
 


### PR DESCRIPTION
Tested on hadoop 2.0.3-alpha.

When saving RDD as text file on hdfs, file output will be cleaned after committing. It is needed to call commitJob after commitTask to fix this problem.

Also updated building file to hadoop 2.0.3-alpha.
