### PR TITLE
Increase ReservedCodeCacheSize for sbt

### DIFF
--- a/sbt/sbt
+++ b/sbt/sbt
@@ -5,4 +5,4 @@ if [ "$MESOS_HOME" != "" ]; then
 fi
 export SPARK_HOME=$(cd "$(dirname $0)/.."; pwd)
 export SPARK_TESTING=1  # To put test classes on classpath
-java -Xmx1200M -XX:MaxPermSize=250m $EXTRA_ARGS -jar $SPARK_HOME/sbt/sbt-launch-*.jar "$@"
+java -Xmx1200m -XX:MaxPermSize=250m -XX:ReservedCodeCacheSize=128m $EXTRA_ARGS -jar $SPARK_HOME/sbt/sbt-launch-*.jar "$@"


### PR DESCRIPTION
Increasing the CodeCache size so that an `sbt/sbt clean package test` reliably finishes with all tests passing (none timing out) and finishes quickly in 10m instead of lingering for >20m.

Please add to `branch-0.7`.
