### PR TITLE
Adding spark.streaming.blockInterval property

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -253,6 +253,13 @@ Apart from these, the following properties are also available, and may be useful
     applications). Note that any RDD that persists in memory for more than this duration will be cleared as well.
   </td>
 </tr>
+<tr>
+  <td>spark.streaming.blockInterval</td>
+  <td>200</td>
+  <td>
+    Duration (milliseconds) of how long to batch new objects coming from network receivers.
+  </td>
+</tr>
 
 </table>
 

--- a/streaming/src/main/scala/spark/streaming/dstream/NetworkInputDStream.scala
+++ b/streaming/src/main/scala/spark/streaming/dstream/NetworkInputDStream.scala
@@ -198,7 +198,7 @@ abstract class NetworkReceiver[T: ClassManifest]() extends Serializable with Log
     case class Block(id: String, iterator: Iterator[T], metadata: Any = null)
 
     val clock = new SystemClock()
-    val blockInterval = 200L
+    val blockInterval = System.getProperty("spark.streaming.blockInterval", "200").toLong
     val blockIntervalTimer = new RecurringTimer(clock, blockInterval, updateCurrentBuffer)
     val blockStorageLevel = storageLevel
     val blocksForPushing = new ArrayBlockingQueue[Block](1000)


### PR DESCRIPTION
This pull request adds spark.streaming.blockInterval property.  Units are in milliseconds and it defaults to 200.

Background info: https://groups.google.com/forum/?fromgroups=#!topic/spark-users/Ow1RiY60oOI

We have used it in our standalone spark streaming cluster today and results have been great.  It has significantly reduced our inode usage and shuffles are much faster now.
