### PR TITLE
Remove spark-repl's extraneous dependency on spark-streaming

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -21,7 +21,7 @@ object SparkBuild extends Build {
 
   lazy val core = Project("core", file("core"), settings = coreSettings)
 
-  lazy val repl = Project("repl", file("repl"), settings = replSettings) dependsOn (core) dependsOn (streaming)
+  lazy val repl = Project("repl", file("repl"), settings = replSettings) dependsOn (core)
 
   lazy val examples = Project("examples", file("examples"), settings = examplesSettings) dependsOn (core) dependsOn (streaming)
 

--- a/repl/pom.xml
+++ b/repl/pom.xml
@@ -97,13 +97,6 @@
           <scope>runtime</scope>
         </dependency>
         <dependency>
-          <groupId>org.spark-project</groupId>
-          <artifactId>spark-streaming</artifactId>
-          <version>${project.version}</version>
-          <classifier>hadoop1</classifier>
-          <scope>runtime</scope>
-        </dependency>
-        <dependency>
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-core</artifactId>
           <scope>provided</scope>
@@ -143,13 +136,6 @@
         <dependency>
           <groupId>org.spark-project</groupId>
           <artifactId>spark-examples</artifactId>
-          <version>${project.version}</version>
-          <classifier>hadoop2</classifier>
-          <scope>runtime</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.spark-project</groupId>
-          <artifactId>spark-streaming</artifactId>
           <version>${project.version}</version>
           <classifier>hadoop2</classifier>
           <scope>runtime</scope>


### PR DESCRIPTION
Per Reynold's request, this patch removes the extraneous dependency `spark-repl` has on `spark-streaming`, which was causing problems in Shark.

This is for `branch-0.7`.
