### PR TITLE
Don't accept generated local directory names that can't be created

### DIFF
--- a/core/src/main/scala/spark/storage/DiskStore.scala
+++ b/core/src/main/scala/spark/storage/DiskStore.scala
@@ -168,8 +168,7 @@ private class DiskStore(blockManager: BlockManager, rootDirs: String)
           localDirId = "%s-%04x".format(dateFormat.format(new Date), rand.nextInt(65536))
           localDir = new File(rootDir, "spark-local-" + localDirId)
           if (!localDir.exists) {
-            localDir.mkdirs()
-            foundLocalDir = true
+            foundLocalDir = localDir.mkdirs()
           }
         } catch {
           case e: Exception =>


### PR DESCRIPTION
Keep trying to create local dirs until one is created, not just that it did not exist before we attempted to create it. This should cause us to fail if spark.local.dir is unwritable and avoid a rare race if two spark executors are starting at the same time on the same machine.
