### PR TITLE
hBase example

### DIFF
--- a/examples/src/main/scala/spark/examples/HBaseTest.scala
+++ b/examples/src/main/scala/spark/examples/HBaseTest.scala
@@ -1,0 +1,34 @@
+package spark.examples
+
+import spark._
+import spark.rdd.NewHadoopRDD
+import org.apache.hadoop.hbase.{HBaseConfiguration, HTableDescriptor, HColumnDescriptor}
+import org.apache.hadoop.hbase.client.HBaseAdmin
+import org.apache.hadoop.hbase.mapreduce.TableInputFormat
+
+object HBaseTest {
+  def main(args: Array[String]) {
+    val sc = new SparkContext(args(0), "HBaseTest",
+      System.getenv("SPARK_HOME"), Seq(System.getenv("SPARK_EXAMPLES_JAR")))
+
+    val conf = HBaseConfiguration.create()
+    conf.set(TableInputFormat.INPUT_TABLE, args(1))
+
+    // Initialize hBase tables if necessary
+    val admin = new HBaseAdmin(conf)
+    if(!admin.isTableAvailable(args(1))) {
+      val colDesc = new HColumnDescriptor(args(2))
+      val tableDesc = new HTableDescriptor(args(1))
+      tableDesc.addFamily(colDesc)
+      admin.createTable(tableDesc)
+    }
+
+    val hBaseRDD = new NewHadoopRDD(sc, classOf[TableInputFormat], 
+                        classOf[org.apache.hadoop.hbase.io.ImmutableBytesWritable],
+                        classOf[org.apache.hadoop.hbase.client.Result], conf)
+
+    hBaseRDD.count()
+
+    System.exit(0)
+  }
+}

--- a/examples/src/main/scala/spark/examples/HBaseTest.scala
+++ b/examples/src/main/scala/spark/examples/HBaseTest.scala
@@ -12,6 +12,9 @@ object HBaseTest {
       System.getenv("SPARK_HOME"), Seq(System.getenv("SPARK_EXAMPLES_JAR")))
 
     val conf = HBaseConfiguration.create()
+
+    // Other options for configuring scan behavior are available. More information available at 
+    // http://hbase.apache.org/apidocs/org/apache/hadoop/hbase/mapreduce/TableInputFormat.html
     conf.set(TableInputFormat.INPUT_TABLE, args(1))
 
     // Initialize hBase table if necessary
@@ -22,8 +25,8 @@ object HBaseTest {
     }
 
     val hBaseRDD = new NewHadoopRDD(sc, classOf[TableInputFormat], 
-                        classOf[org.apache.hadoop.hbase.io.ImmutableBytesWritable],
-                        classOf[org.apache.hadoop.hbase.client.Result], conf)
+      classOf[org.apache.hadoop.hbase.io.ImmutableBytesWritable],
+      classOf[org.apache.hadoop.hbase.client.Result], conf)
 
     hBaseRDD.count()
 

--- a/examples/src/main/scala/spark/examples/HBaseTest.scala
+++ b/examples/src/main/scala/spark/examples/HBaseTest.scala
@@ -24,9 +24,9 @@ object HBaseTest {
       admin.createTable(tableDesc)
     }
 
-    val hBaseRDD = new NewHadoopRDD(sc, classOf[TableInputFormat], 
+    val hBaseRDD = sc.newAPIHadoopRDD(conf, classOf[TableInputFormat], 
       classOf[org.apache.hadoop.hbase.io.ImmutableBytesWritable],
-      classOf[org.apache.hadoop.hbase.client.Result], conf)
+      classOf[org.apache.hadoop.hbase.client.Result])
 
     hBaseRDD.count()
 

--- a/examples/src/main/scala/spark/examples/HBaseTest.scala
+++ b/examples/src/main/scala/spark/examples/HBaseTest.scala
@@ -2,7 +2,7 @@ package spark.examples
 
 import spark._
 import spark.rdd.NewHadoopRDD
-import org.apache.hadoop.hbase.{HBaseConfiguration, HTableDescriptor, HColumnDescriptor}
+import org.apache.hadoop.hbase.{HBaseConfiguration, HTableDescriptor}
 import org.apache.hadoop.hbase.client.HBaseAdmin
 import org.apache.hadoop.hbase.mapreduce.TableInputFormat
 
@@ -14,12 +14,10 @@ object HBaseTest {
     val conf = HBaseConfiguration.create()
     conf.set(TableInputFormat.INPUT_TABLE, args(1))
 
-    // Initialize hBase tables if necessary
+    // Initialize hBase table if necessary
     val admin = new HBaseAdmin(conf)
     if(!admin.isTableAvailable(args(1))) {
-      val colDesc = new HColumnDescriptor(args(2))
       val tableDesc = new HTableDescriptor(args(1))
-      tableDesc.addFamily(colDesc)
       admin.createTable(tableDesc)
     }
 

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -200,7 +200,11 @@ object SparkBuild extends Build {
 
   def examplesSettings = sharedSettings ++ Seq(
     name := "spark-examples",
-    libraryDependencies ++= Seq("com.twitter" % "algebird-core_2.9.2" % "0.1.11")
+    resolvers ++= Seq("Apache HBase" at "https://repository.apache.org/content/repositories/releases"),
+    libraryDependencies ++= Seq(
+      "com.twitter" % "algebird-core_2.9.2" % "0.1.11",
+      "org.apache.hbase" % "hbase" % "0.94.6"
+    )
   )
 
   def bagelSettings = sharedSettings ++ Seq(name := "spark-bagel")


### PR DESCRIPTION
This pull request provides an example of creating a NewHadoopRDD based on an hBase table. The HBaseTest class has a "main" method that takes two arguments: (1) the first SparkContext configuration parameter and (2) the hBase table name in String format. If the table does not already exist, the example will create it.

hBase resources are also added to SparkBuild.scala under the section for the examples project.

I wrote this code myself and I'm the copyright holder. I license it to the Spark/Mesos project under the project's license (BSD).
