### PR TITLE
Fix SPARK-670: EC2 'start' command should require -i option.

### DIFF
--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -103,7 +103,7 @@ def parse_args():
     parser.print_help()
     sys.exit(1)
   (action, cluster_name) = args
-  if opts.identity_file == None and action in ['launch', 'login']:
+  if opts.identity_file == None and action in ['launch', 'login', 'start']:
     print >> stderr, ("ERROR: The -i or --identity-file argument is " +
                       "required for " + action)
     sys.exit(1)


### PR DESCRIPTION
This fixes [SPARK-670](https://spark-project.atlassian.net/browse/SPARK-670): "spark-ec2 should warn if you use the "start" command without passing a SSH key file".
