### PR TITLE
Use default classloaders for akka & deserializing task results

### DIFF
--- a/core/src/main/scala/spark/scheduler/cluster/TaskSetManager.scala
+++ b/core/src/main/scala/spark/scheduler/cluster/TaskSetManager.scala
@@ -503,9 +503,16 @@ private[spark] class TaskSetManager(sched: ClusterScheduler, val taskSet: TaskSe
       logInfo("Finished TID %s in %d ms (progress: %d/%d)".format(
         tid, info.duration, tasksFinished, numTasks))
       // Deserialize task result and pass it to the scheduler
-      val result = ser.deserialize[TaskResult[_]](serializedData, getClass.getClassLoader)
-      result.metrics.resultSize = serializedData.limit()
-      sched.listener.taskEnded(tasks(index), Success, result.value, result.accumUpdates, info, result.metrics)
+      try {
+        val result = ser.deserialize[TaskResult[_]](serializedData)
+        result.metrics.resultSize = serializedData.limit()
+        sched.listener.taskEnded(tasks(index), Success, result.value, result.accumUpdates, info, result.metrics)
+      } catch {
+        case cnf: ClassNotFoundException =>
+          val loader = Thread.currentThread().getContextClassLoader
+          throw new SparkException("ClassNotFound with classloader: " + loader, cnf)
+        case ex => throw ex
+      }
       // Mark finished and stop if we've finished all the tasks
       finished(index) = true
       if (tasksFinished == numTasks) {

--- a/core/src/main/scala/spark/util/AkkaUtils.scala
+++ b/core/src/main/scala/spark/util/AkkaUtils.scala
@@ -52,7 +52,7 @@ private[spark] object AkkaUtils {
       """.format(host, port, akkaTimeout, akkaFrameSize, akkaThreads, akkaBatchSize,
         lifecycleEvents, akkaWriteTimeout))
 
-    val actorSystem = ActorSystem(name, akkaConf, getClass.getClassLoader)
+    val actorSystem = ActorSystem(name, akkaConf)
 
     // Figure out the port number we bound to, in case port was passed as 0. This is a bit of a
     // hack because Akka doesn't let you figure out the port through the public API yet.


### PR DESCRIPTION
This changes spark to use the default class loader, instead of the classloader of the current class, when starting akka & when deserializing task results, as discussed here: https://groups.google.com/forum/?fromgroups=#!topic/spark-developers/SUmLIHpw1x0

The change is very small, but the effects probably aren't obvious.  Its needed for when you want to add a jar of user code after the spark context is started with `sc.addJar`.  The `Executor`s already updated to use the code of the jar, but before this change, they could send a message back with a class the driver didn't know how to load, which lead to a `ClassNotFoundException`.

The thing is, before the change, it _might_ work.  You might get the jar in all of the currently active akka threads.  And for a lot of tasks, that was good enough.  But, on some workloads, akka decides to launch a whole bunch of new threads.  Then those threads wont' have a classloader that knows about the new jar.

This change alone isn't a complete solution -- if you call `sc.addJar`, it still doesn't add the jar to the class loader for the driver.  You still need to reset your classloader to let you add jars, just like is done in `Executor`s.  With this change, at least its possible to do that.  Or I could add something similar to the driver itself.

I ran tests with standalone jobs & the shell, in local mode & the cluster, as Matei suggested.  But I'd appreciate other ideas on how to test it, particularly given my experience that only some workloads can cause akka to spawn more threads.
