### PR TITLE
Adding dropTake to RDD. Allows to drop first 'drop' elements and then take next 'take' elements

### DIFF
--- a/core/src/test/scala/spark/RDDSuite.scala
+++ b/core/src/test/scala/spark/RDDSuite.scala
@@ -26,6 +26,8 @@ class RDDSuite extends FunSuite with LocalSparkContext {
     assert(nums.union(nums).collect().toList === List(1, 2, 3, 4, 1, 2, 3, 4))
     assert(nums.glom().map(_.toList).collect().toList === List(List(1, 2), List(3, 4)))
     assert(nums.collect({ case i if i >= 3 => i.toString }).collect().toList === List("3", "4"))
+    assert(nums.take(2).toList === List(1, 2))
+    assert(nums.dropTake(1,2).toList === List(2, 3))
     assert(nums.keyBy(_.toString).collect().toList === List(("1", 1), ("2", 2), ("3", 3), ("4", 4)))
     val partitionSums = nums.mapPartitions(iter => Iterator(iter.reduceLeft(_ + _)))
     assert(partitionSums.collect().toList === List(3, 7))


### PR DESCRIPTION
1. Added a dropTake(drop: Int, num: Int) method which will drop first 'drop' elements and then take the next 'num' elements.
2. Added a test for take(num: Int)
3. Added a test for dropTake(drop: Int, num: Int) 
