### PR TITLE
Use ec2-metadata in start-slave.sh to detect if running on EC2

### DIFF
--- a/bin/start-slave.sh
+++ b/bin/start-slave.sh
@@ -6,7 +6,8 @@ bin=`cd "$bin"; pwd`
 # Set SPARK_PUBLIC_DNS so slaves can be linked in master web UI
 if [ "$SPARK_PUBLIC_DNS" = "" ]; then
     # If we appear to be running on EC2, use the public address by default:
-    if [[ `hostname` == *ec2.internal ]]; then
+    # NOTE: ec2-metadata is installed on Amazon Linux AMI. Check based on that and hostname
+    if command -v ec2-metadata > /dev/null || [[ `hostname` == *ec2.internal ]]; then
         export SPARK_PUBLIC_DNS=`wget -q -O - http://instance-data.ec2.internal/latest/meta-data/public-hostname`
     fi
 fi


### PR DESCRIPTION
This should finally fix [SPARK-613](https://spark-project.atlassian.net/browse/SPARK-613), the issue where the standalone web UI would link to internal addresses.

It turns out that #419 applied the same change, but only to `start-master.sh`, so some workers were still starting their web UI's using internal addresses.

After merging, please cherry-pick this into branch-0.7.
