### PR TITLE
Fix start-slave not passing instance number to spark-daemon.

### DIFF
--- a/bin/start-slave.sh
+++ b/bin/start-slave.sh
@@ -12,4 +12,4 @@ if [ "$SPARK_PUBLIC_DNS" = "" ]; then
     fi
 fi
 
-"$bin"/spark-daemon.sh start spark.deploy.worker.Worker "$@"
+"$bin"/spark-daemon.sh start spark.deploy.worker.Worker 1 "$@"


### PR DESCRIPTION
We updated to a snapshot version of master and our calls to start-slave failed because spark-daemon now expects number-of-instances as a parameter before the command args.
