### PR TITLE
Fix block manager UI display issue when enable spark.cleaner.ttl

### DIFF
--- a/core/src/main/scala/spark/storage/StorageUtils.scala
+++ b/core/src/main/scala/spark/storage/StorageUtils.scala
@@ -64,12 +64,12 @@ object StorageUtils {
       // Find the id of the RDD, e.g. rdd_1 => 1
       val rddId = rddKey.split("_").last.toInt
       // Get the friendly name for the rdd, if available.
-      val rdd = sc.persistentRdds(rddId)
-      val rddName = Option(rdd.name).getOrElse(rddKey)
-      val rddStorageLevel = rdd.getStorageLevel
-
-      RDDInfo(rddId, rddName, rddStorageLevel, rddBlocks.length, rdd.partitions.size, memSize, diskSize)
-    }.toArray
+      sc.persistentRdds.get(rddId).map { r =>
+          val rddName = Option(r.name).getOrElse(rddKey)
+          val rddStorageLevel = r.getStorageLevel
+          RDDInfo(rddId, rddName, rddStorageLevel, rddBlocks.length, r.partitions.size, memSize, diskSize)
+      }
+    }.flatMap(x => x).toArray
 
     scala.util.Sorting.quickSort(rddInfos)
 


### PR DESCRIPTION
When spark.cleaner.ttl is enabled, RDD id got from BlockManger's block id may not have correspondence in SparkContext's `persistentRdds`, `persistentRdds` has already clean up this RDD, which will make `val rdd = sc.persistentRdds(rddId)` throw `NoSuchElementException` . So here cleaned RDD should be filted out.
