### PR TITLE
[Spark-753] Fix ClusterSchedulSuite unit test failed 

### DIFF
--- a/core/src/main/scala/spark/scheduler/cluster/SchedulingAlgorithm.scala
+++ b/core/src/main/scala/spark/scheduler/cluster/SchedulingAlgorithm.scala
@@ -40,15 +40,24 @@ private[spark] class FairSchedulingAlgorithm extends SchedulingAlgorithm {
     val taskToWeightRatio1 = runningTasks1.toDouble / s1.weight.toDouble
     val taskToWeightRatio2 = runningTasks2.toDouble / s2.weight.toDouble
     var res:Boolean = true
+    var compare:Int = 0
 
     if (s1Needy && !s2Needy) {
-      res = true
+      return true
     } else if (!s1Needy && s2Needy) {
-      res = false
+      return false
     } else if (s1Needy && s2Needy) {
-      res = minShareRatio1 <= minShareRatio2
+      compare = minShareRatio1.compareTo(minShareRatio2)
     } else {
-      res = taskToWeightRatio1 <= taskToWeightRatio2
+      compare = taskToWeightRatio1.compareTo(taskToWeightRatio2)
+    }
+
+    if (compare < 0) {
+      res = true
+    } else if (compare > 0) {
+      res = false
+    } else {
+      return s1.name < s2.name
     }
     return res
   }

--- a/core/src/test/scala/spark/scheduler/ClusterSchedulerSuite.scala
+++ b/core/src/test/scala/spark/scheduler/ClusterSchedulerSuite.scala
@@ -88,7 +88,7 @@ class DummyTask(stageId: Int) extends Task[Int](stageId)
   }
 }
 
-class ClusterSchedulerSuite extends FunSuite with LocalSparkContext {
+class ClusterSchedulerSuite extends FunSuite with LocalSparkContext with Logging {
 
   def createDummyTaskSetManager(priority: Int, stage: Int, numTasks: Int, cs: ClusterScheduler, taskSet: TaskSet): DummyTaskSetManager = {
     new DummyTaskSetManager(priority, stage, numTasks, cs , taskSet)
@@ -96,8 +96,11 @@ class ClusterSchedulerSuite extends FunSuite with LocalSparkContext {
 
   def resourceOffer(rootPool: Pool): Int = {
     val taskSetQueue = rootPool.getSortedTaskSetQueue()
-    for (taskSet <- taskSetQueue)
-    {
+    /* Just for Test*/
+    for (manager <- taskSetQueue) {
+       logInfo("parentName:%s, parent running tasks:%d, name:%s,runningTasks:%d".format(manager.parent.name, manager.parent.runningTasks, manager.name, manager.runningTasks))
+    }
+    for (taskSet <- taskSetQueue) {
       taskSet.slaveOffer("execId_1", "hostname_1", 1) match {
         case Some(task) =>
           return taskSet.stageId


### PR DESCRIPTION
Due to some non-determinism scenarios in unit test, it will failed depend on environment, for examples

info ClusterSchedulerSuite:
info - FIFO Scheduler Test
INFO 05/30/2013 14:56:15.332 spray-io-worker-0 IoWorker IoWorker thread 'spray-io-worker-0' stopped info - Fair Scheduler Test **\* FAILED ***
info 3 did not equal 0 (ClusterSchedulerSuite.scala:111)
INFO 05/30/2013 14:56:15.540 spray-io-worker-0 IoWorker IoWorker thread 'spray-io-worker-0' stopped info - Nested Pool Test **\* FAILED ***
info 7 did not equal 0 (ClusterSchedulerSuite.scala:111)
INFO 05/30/2013 14:56:15.712 spray-io-worker-0 IoWorker IoWorker thread 'spray-io-worker-0' stopped error Failed: : Total 3, Failed 2, Errors 0, Passed 1, Skipped 0 error Failed tests:
error spark.scheduler.ClusterSchedulerSuite
error (core/test:test-only) sbt.TestsFailedException: Tests unsuccessful error Total time: 5 s, completed May 30, 2013 2:56:15 PM
