### PR TITLE
Enhance pipe to support more features we can do in hadoop streaming

### DIFF
--- a/core/src/main/scala/spark/RDD.scala
+++ b/core/src/main/scala/spark/RDD.scala
@@ -351,13 +351,31 @@ abstract class RDD[T: ClassManifest](
   /**
    * Return an RDD created by piping elements to a forked external process.
    */
+  def pipe(command: String, transform: (T,String => Unit) => Any, arguments: Seq[String]): RDD[String] = 
+    new PipedRDD(this, command, transform, arguments)
+
+  /**
+   * Return an RDD created by piping elements to a forked external process.
+   */
   def pipe(command: Seq[String]): RDD[String] = new PipedRDD(this, command)
+
+  /**
+   * Return an RDD created by piping elements to a forked external process.
+   */
+  def pipe(command: Seq[String], transform: (T,String => Unit) => Any, arguments: Seq[String]): RDD[String] = 
+    new PipedRDD(this, command, transform, arguments)
 
   /**
    * Return an RDD created by piping elements to a forked external process.
    */
   def pipe(command: Seq[String], env: Map[String, String]): RDD[String] =
     new PipedRDD(this, command, env)
+
+  /**
+   * Return an RDD created by piping elements to a forked external process.
+   */
+  def pipe(command: Seq[String], env: Map[String, String], transform: (T,String => Unit) => Any, arguments: Seq[String]): RDD[String] = 
+    new PipedRDD(this, command, env, transform, arguments)
 
   /**
    * Return a new RDD by applying a function to each partition of this RDD.

--- a/core/src/main/scala/spark/RDD.scala
+++ b/core/src/main/scala/spark/RDD.scala
@@ -361,24 +361,30 @@ abstract class RDD[T: ClassManifest](
 
   /**
    * Return an RDD created by piping elements to a forked external process.
-   * How each record in RDD is outputed to the process can be controled by providing a
-   * function trasnform(T, outputFunction: String => Unit). transform() will be called with
-   * the currnet record in RDD as the 1st parameter, and the function to output the record to
-   * the external process (like out.println()) as the 2nd parameter.
-   * Here's an example on how to pipe the RDD data of groupBy() in a streaming way,
-   * instead of constructing a huge String to concat all the records:
-   * def tranform(record:(String, Seq[String]), f:String=>Unit) = for (e <- record._2){f(e)}
-   * pipeContext can be used to transfer additional context data to the external process
-   * besides the RDD. pipeContext is a broadcast Seq[String], each line would be piped to
-   * external process with "^A" as the delimiter in the end of context data. Delimiter can also 
-   * be customized by the last parameter delimiter.
+   * The print behavior can be customized by providing two functions.
+   *
+   * @param command command to run in forked process.
+   * @param env environment variables to set.
+   * @param printPipeContext Before piping elements, this function is called as an oppotunity
+   *                         to pipe context data. Print line function (like out.println) will be 
+   *                         passed as printPipeContext's parameter.
+   * @param printPipeContext Use this function to customize how to pipe elements. This function 
+   *                         will be called with each RDD element as the 1st parameter, and the 
+   *                         print line function (like out.println()) as the 2nd parameter.
+   *                         An example of pipe the RDD data of groupBy() in a streaming way,
+   *                         instead of constructing a huge String to concat all the elements:
+   *                         def printRDDElement(record:(String, Seq[String]), f:String=>Unit) = 
+   *                           for (e <- record._2){f(e)}
+   * @return the result RDD
    */
   def pipe(
       command: Seq[String], 
       env: Map[String, String] = Map(), 
       printPipeContext: (String => Unit) => Unit = null,
       printRDDElement: (T, String => Unit) => Unit = null): RDD[String] = 
-    new PipedRDD(this, command, env, if (printPipeContext ne null) sc.clean(printPipeContext) else null, printRDDElement)
+    new PipedRDD(this, command, env, 
+      if (printPipeContext ne null) sc.clean(printPipeContext) else null, 
+      if (printRDDElement ne null) sc.clean(printRDDElement) else null)
 
   /**
    * Return a new RDD by applying a function to each partition of this RDD.

--- a/core/src/main/scala/spark/RDD.scala
+++ b/core/src/main/scala/spark/RDD.scala
@@ -16,6 +16,7 @@ import org.apache.hadoop.mapred.TextOutputFormat
 
 import it.unimi.dsi.fastutil.objects.{Object2LongOpenHashMap => OLMap}
 
+import spark.broadcast.Broadcast
 import spark.Partitioner._
 import spark.partial.BoundedDouble
 import spark.partial.CountEvaluator
@@ -351,31 +352,93 @@ abstract class RDD[T: ClassManifest](
   /**
    * Return an RDD created by piping elements to a forked external process.
    */
-  def pipe(command: String, transform: (T,String => Unit) => Any, arguments: Seq[String]): RDD[String] = 
-    new PipedRDD(this, command, transform, arguments)
-
-  /**
-   * Return an RDD created by piping elements to a forked external process.
-   */
-  def pipe(command: Seq[String]): RDD[String] = new PipedRDD(this, command)
-
-  /**
-   * Return an RDD created by piping elements to a forked external process.
-   */
-  def pipe(command: Seq[String], transform: (T,String => Unit) => Any, arguments: Seq[String]): RDD[String] = 
-    new PipedRDD(this, command, transform, arguments)
-
-  /**
-   * Return an RDD created by piping elements to a forked external process.
-   */
-  def pipe(command: Seq[String], env: Map[String, String]): RDD[String] =
+  def pipe(command: String, env: Map[String, String]): RDD[String] = 
     new PipedRDD(this, command, env)
 
   /**
    * Return an RDD created by piping elements to a forked external process.
+   * How each record in RDD is outputed to the process can be controled by providing a
+   * function trasnform(T, outputFunction: String => Unit). transform() will be called with
+   * the currnet record in RDD as the 1st parameter, and the function to output the record to
+   * the external process (like out.println()) as the 2nd parameter.
+   * Here's an example on how to pipe the RDD data of groupBy() in a streaming way,
+   * instead of constructing a huge String to concat all the records:
+   * def tranform(record:(String, Seq[String]), f:String=>Unit) = for (e <- record._2){f(e)}
+   * pipeContext can be used to transfer additional context data to the external process
+   * besides the RDD. pipeContext is a broadcast Seq[String], each line would be piped to
+   * external process with "^A" as the delimiter in the end of context data. Delimiter can also 
+   * be customized by the last parameter delimiter.
    */
-  def pipe(command: Seq[String], env: Map[String, String], transform: (T,String => Unit) => Any, arguments: Seq[String]): RDD[String] = 
-    new PipedRDD(this, command, env, transform, arguments)
+  def pipe[U<: Seq[String]](
+      command: String, 
+      env: Map[String, String],
+      transform: (T,String => Unit) => Any,
+      pipeContext: Broadcast[U],
+      delimiter: String): RDD[String] = 
+    new PipedRDD(this, command, env, transform, pipeContext, delimiter)
+
+  /**
+   * Return an RDD created by piping elements to a forked external process.
+   * How each record in RDD is outputed to the process can be controled by providing a
+   * function trasnform(T, outputFunction: String => Unit). transform() will be called with
+   * the currnet record in RDD as the 1st parameter, and the function to output the record to
+   * the external process (like out.println()) as the 2nd parameter.
+   * Here's an example on how to pipe the RDD data of groupBy() in a streaming way,
+   * instead of constructing a huge String to concat all the records:
+   * def tranform(record:(String, Seq[String]), f:String=>Unit) = for (e <- record._2){f(e)}
+   * pipeContext can be used to transfer additional context data to the external process
+   * besides the RDD. pipeContext is a broadcast Seq[String], each line would be piped to
+   * external process with "^A" as the delimiter in the end of context data. Delimiter can also 
+   * be customized by the last parameter delimiter.
+   */
+  def pipe[U<: Seq[String]](
+      command: String, 
+      transform: (T,String => Unit) => Any,
+      pipeContext: Broadcast[U]): RDD[String] = 
+    new PipedRDD(this, command, Map[String, String](), transform, pipeContext, "\u0001")
+
+  /**
+   * Return an RDD created by piping elements to a forked external process.
+   * How each record in RDD is outputed to the process can be controled by providing a
+   * function trasnform(T, outputFunction: String => Unit). transform() will be called with
+   * the currnet record in RDD as the 1st parameter, and the function to output the record to
+   * the external process (like out.println()) as the 2nd parameter.
+   * Here's an example on how to pipe the RDD data of groupBy() in a streaming way,
+   * instead of constructing a huge String to concat all the records:
+   * def tranform(record:(String, Seq[String]), f:String=>Unit) = for (e <- record._2){f(e)}
+   * pipeContext can be used to transfer additional context data to the external process
+   * besides the RDD. pipeContext is a broadcast Seq[String], each line would be piped to
+   * external process with "^A" as the delimiter in the end of context data. Delimiter can also 
+   * be customized by the last parameter delimiter.
+   */
+  def pipe[U<: Seq[String]](
+      command: String, 
+      env: Map[String, String],
+      transform: (T,String => Unit) => Any,
+      pipeContext: Broadcast[U]): RDD[String] = 
+    new PipedRDD(this, command, env, transform, pipeContext, "\u0001")
+
+  /**
+   * Return an RDD created by piping elements to a forked external process.
+   * How each record in RDD is outputed to the process can be controled by providing a
+   * function trasnform(T, outputFunction: String => Unit). transform() will be called with
+   * the currnet record in RDD as the 1st parameter, and the function to output the record to
+   * the external process (like out.println()) as the 2nd parameter.
+   * Here's an example on how to pipe the RDD data of groupBy() in a streaming way,
+   * instead of constructing a huge String to concat all the records:
+   * def tranform(record:(String, Seq[String]), f:String=>Unit) = for (e <- record._2){f(e)}
+   * pipeContext can be used to transfer additional context data to the external process
+   * besides the RDD. pipeContext is a broadcast Seq[String], each line would be piped to
+   * external process with "^A" as the delimiter in the end of context data. Delimiter can also 
+   * be customized by the last parameter delimiter.
+   */
+  def pipe[U<: Seq[String]](
+      command: Seq[String], 
+      env: Map[String, String] = Map(), 
+      transform: (T,String => Unit) => Any = null, 
+      pipeContext: Broadcast[U] = null,
+      delimiter: String = "\u0001"): RDD[String] = 
+    new PipedRDD(this, command, env, transform, pipeContext, delimiter)
 
   /**
    * Return a new RDD by applying a function to each partition of this RDD.

--- a/core/src/test/scala/spark/PipedRDDSuite.scala
+++ b/core/src/test/scala/spark/PipedRDDSuite.scala
@@ -19,6 +19,37 @@ class PipedRDDSuite extends FunSuite with LocalSparkContext {
     assert(c(3) === "4")
   }
 
+  test("advanced pipe") {
+    sc = new SparkContext("local", "test")
+    val nums = sc.makeRDD(Array(1, 2, 3, 4), 2)
+
+    val piped = nums.pipe(Seq("cat"), (i:Int, f: String=> Unit) => f(i + "_"), Array("0"))
+
+    val c = piped.collect()
+
+    assert(c.size === 8)
+    assert(c(0) === "0")
+    assert(c(1) === "\u0001")
+    assert(c(2) === "1_")
+    assert(c(3) === "2_")
+    assert(c(4) === "0")
+    assert(c(5) === "\u0001")
+    assert(c(6) === "3_")
+    assert(c(7) === "4_")
+
+    val nums1 = sc.makeRDD(Array("a\t1", "b\t2", "a\t3", "b\t4"), 2)
+    val d = nums1.groupBy(str=>str.split("\t")(0)).pipe(Seq("cat"), (i:Tuple2[String, Seq[String]], f: String=> Unit) => {for (e <- i._2){ f(e + "_")}}, Array("0")).collect()
+    assert(d.size === 8)
+    assert(d(0) === "0")
+    assert(d(1) === "\u0001")
+    assert(d(2) === "b\t2_")
+    assert(d(3) === "b\t4_")
+    assert(d(4) === "0")
+    assert(d(5) === "\u0001")
+    assert(d(6) === "a\t1_")
+    assert(d(7) === "a\t3_")
+  }
+
   test("pipe with env variable") {
     sc = new SparkContext("local", "test")
     val nums = sc.makeRDD(Array(1, 2, 3, 4), 2)

--- a/core/src/test/scala/spark/PipedRDDSuite.scala
+++ b/core/src/test/scala/spark/PipedRDDSuite.scala
@@ -23,7 +23,8 @@ class PipedRDDSuite extends FunSuite with LocalSparkContext {
     sc = new SparkContext("local", "test")
     val nums = sc.makeRDD(Array(1, 2, 3, 4), 2)
 
-    val piped = nums.pipe(Seq("cat"), (i:Int, f: String=> Unit) => f(i + "_"), Array("0"))
+    val piped = nums.pipe(Seq("cat"), Map[String, String](), 
+      (i:Int, f: String=> Unit) => f(i + "_"), sc.broadcast(List("0")))
 
     val c = piped.collect()
 
@@ -38,7 +39,9 @@ class PipedRDDSuite extends FunSuite with LocalSparkContext {
     assert(c(7) === "4_")
 
     val nums1 = sc.makeRDD(Array("a\t1", "b\t2", "a\t3", "b\t4"), 2)
-    val d = nums1.groupBy(str=>str.split("\t")(0)).pipe(Seq("cat"), (i:Tuple2[String, Seq[String]], f: String=> Unit) => {for (e <- i._2){ f(e + "_")}}, Array("0")).collect()
+    val d = nums1.groupBy(str=>str.split("\t")(0)).
+      pipe(Seq("cat"), Map[String, String](), (i:Tuple2[String, Seq[String]], f: String=> Unit) => 
+      {for (e <- i._2){ f(e + "_")}}, sc.broadcast(List("0"))).collect()
     assert(d.size === 8)
     assert(d(0) === "0")
     assert(d(1) === "\u0001")


### PR DESCRIPTION
In Yahoo we want to migrate some of our hadoop based pipelines to Spark. Our pipelines are mostly implemented in hadoop streaming. We hope we can reuse most of the hadoop streaming code so that we can reduce the effort of the migration, and maybe only focus on rewriting the perf bottleneck. In our prototyping we saw that reusing existing code we can still get significant perf improvement. This should be also helpful for other users if they are currently using hadoop and want to change to Spark.

Though Spark has rdd.pipe() to do some similar work as hadoop streaming, we found some use cases as following still couldn't be supported.
1. We have some problem with reuse the reducer side hadoop streaming code with pipe(). The problem we had was, in our use case, after keyBy() or groupBy() the size of the data for some key can be very big. If we resolve this problem using map() then pipe(), we need to construct a big string to concat all the strings in the Seq[String] of the RDD of one key, this would consume a quite big chunk of memory in some cases, and seems like a not very scalable and performant solution. Especially Spark is a so memory intensive system, optimizing memory usage is very important for us.
2. Sometimes in hadoop streaming we need to use distributed cache(-cacheFile, -cacheArchive) to distribute the shared data to all tasktrackers. We need some similar mechanism in spark to do the same thing.

In this Pull Request, we enhanced the pipeRdd and rdd.pipe() to support above 2 features. For 1st, we allow user of pipe() to provide a function to specify how to transform the content of RDD and do the outputing. For 2nd, we allow user to provide a Seq[String] which will be piped to the shell process. User can use broadcast values to implement the similar feature as distributed cache in hadoop streaming.
