### PR TITLE
Add top K method to RDD using a bounded priority queue

### DIFF
--- a/core/src/main/scala/spark/RDD.scala
+++ b/core/src/main/scala/spark/RDD.scala
@@ -35,6 +35,7 @@ import spark.rdd.ZippedPartitionsRDD2
 import spark.rdd.ZippedPartitionsRDD3
 import spark.rdd.ZippedPartitionsRDD4
 import spark.storage.StorageLevel
+import spark.util.BoundedPriorityQueue
 
 import SparkContext._
 
@@ -720,6 +721,29 @@ abstract class RDD[T: ClassManifest](
   def first(): T = take(1) match {
     case Array(t) => t
     case _ => throw new UnsupportedOperationException("empty collection")
+  }
+
+  /**
+   * Returns the top K elements from this RDD as defined by
+   * the specified implicit Ordering[T].
+   * @param num the number of top elements to return
+   * @param ord the implicit ordering for T
+   * @return an array of top elements
+   */
+  def top(num: Int)(implicit ord: Ordering[T]): Array[T] = {
+    val topK = mapPartitions { items =>
+      val queue = new BoundedPriorityQueue[T](num)
+      queue ++= items
+      Iterator(queue)
+    }.reduce { (queue1, queue2) =>
+      queue1 ++= queue2
+      queue1
+    }
+
+    val builder = Array.newBuilder[T]
+    builder.sizeHint(topK.size)
+    builder ++= topK
+    builder.result()
   }
 
   /**

--- a/core/src/main/scala/spark/RDD.scala
+++ b/core/src/main/scala/spark/RDD.scala
@@ -731,19 +731,14 @@ abstract class RDD[T: ClassManifest](
    * @return an array of top elements
    */
   def top(num: Int)(implicit ord: Ordering[T]): Array[T] = {
-    val topK = mapPartitions { items =>
+    mapPartitions { items =>
       val queue = new BoundedPriorityQueue[T](num)
       queue ++= items
       Iterator.single(queue)
     }.reduce { (queue1, queue2) =>
       queue1 ++= queue2
       queue1
-    }
-
-    val builder = Array.newBuilder[T]
-    builder.sizeHint(topK.size)
-    builder ++= topK
-    builder.result()
+    }.toArray
   }
 
   /**

--- a/core/src/main/scala/spark/RDD.scala
+++ b/core/src/main/scala/spark/RDD.scala
@@ -734,7 +734,7 @@ abstract class RDD[T: ClassManifest](
     val topK = mapPartitions { items =>
       val queue = new BoundedPriorityQueue[T](num)
       queue ++= items
-      Iterator(queue)
+      Iterator.single(queue)
     }.reduce { (queue1, queue2) =>
       queue1 ++= queue2
       queue1

--- a/core/src/main/scala/spark/api/java/JavaRDD.scala
+++ b/core/src/main/scala/spark/api/java/JavaRDD.scala
@@ -86,7 +86,6 @@ JavaRDDLike[T, JavaRDD[T]] {
    */
   def subtract(other: JavaRDD[T], p: Partitioner): JavaRDD[T] =
     wrapRDD(rdd.subtract(other, p))
-
 }
 
 object JavaRDD {

--- a/core/src/main/scala/spark/api/java/JavaRDDLike.scala
+++ b/core/src/main/scala/spark/api/java/JavaRDDLike.scala
@@ -1,6 +1,6 @@
 package spark.api.java
 
-import java.util.{List => JList}
+import java.util.{List => JList, Comparator}
 import scala.Tuple2
 import scala.collection.JavaConversions._
 
@@ -350,5 +350,30 @@ trait JavaRDDLike[T, This <: JavaRDDLike[T, This]] extends Serializable {
   /** A description of this RDD and its recursive dependencies for debugging. */
   def toDebugString(): String = {
     rdd.toDebugString
+  }
+
+  /**
+   * Returns the top K elements from this RDD as defined by
+   * the specified Comparator[T].
+   * @param num the number of top elements to return
+   * @param comp the comparator that defines the order
+   * @return an array of top elements
+   */
+  def top(num: Int, comp: Comparator[T]): JList[T] = {
+    import scala.collection.JavaConversions._
+    val topElems = rdd.top(num)(Ordering.comparatorToOrdering(comp))
+    val arr: java.util.Collection[T] = topElems.toSeq
+    new java.util.ArrayList(arr)
+  }
+
+  /**
+   * Returns the top K elements from this RDD using the
+   * natural ordering for T.
+   * @param num the number of top elements to return
+   * @return an array of top elements
+   */
+  def top(num: Int): JList[T] = {
+    val comp = com.google.common.collect.Ordering.natural().asInstanceOf[Comparator[T]]
+    top(num, comp)
   }
 }

--- a/core/src/main/scala/spark/util/BoundedPriorityQueue.scala
+++ b/core/src/main/scala/spark/util/BoundedPriorityQueue.scala
@@ -1,0 +1,48 @@
+package spark.util
+
+import java.util.{PriorityQueue => JPriorityQueue}
+import scala.collection.generic.Growable
+
+/**
+ * Bounded priority queue. This class modifies the original PriorityQueue's
+ * add/offer methods such that only the top K elements are retained. The top
+ * K elements are defined by an implicit Ordering[A].
+ */
+class BoundedPriorityQueue[A](maxSize: Int)(implicit ord: Ordering[A], mf: ClassManifest[A])
+  extends JPriorityQueue[A](maxSize, ord) with Growable[A] {
+
+  override def offer(a: A): Boolean  = {
+    if (size < maxSize) super.offer(a)
+    else maybeReplaceLowest(a)
+  }
+
+  override def add(a: A): Boolean = offer(a)
+
+  override def ++=(xs: TraversableOnce[A]): this.type = {
+    xs.foreach(add)
+    this
+  }
+
+  override def +=(elem: A): this.type = {
+    add(elem)
+    this
+  }
+
+  override def +=(elem1: A, elem2: A, elems: A*): this.type = {
+    this += elem1 += elem2 ++= elems
+  }
+
+  private def maybeReplaceLowest(a: A): Boolean = {
+    val head = peek()
+    if (head != null && ord.gt(a, head)) {
+      poll()
+      super.offer(a)
+    } else false
+  }
+}
+
+object BoundedPriorityQueue {
+  import scala.collection.JavaConverters._
+  implicit def asIterable[A](queue: BoundedPriorityQueue[A]): Iterable[A] = queue.asScala
+}
+

--- a/core/src/main/scala/spark/util/BoundedPriorityQueue.scala
+++ b/core/src/main/scala/spark/util/BoundedPriorityQueue.scala
@@ -8,7 +8,7 @@ import scala.collection.generic.Growable
  * add/offer methods such that only the top K elements are retained. The top
  * K elements are defined by an implicit Ordering[A].
  */
-class BoundedPriorityQueue[A](maxSize: Int)(implicit ord: Ordering[A], mf: ClassManifest[A])
+class BoundedPriorityQueue[A](maxSize: Int)(implicit ord: Ordering[A])
   extends JPriorityQueue[A](maxSize, ord) with Growable[A] {
 
   override def offer(a: A): Boolean  = {

--- a/core/src/test/scala/spark/RDDSuite.scala
+++ b/core/src/test/scala/spark/RDDSuite.scala
@@ -317,4 +317,23 @@ class RDDSuite extends FunSuite with LocalSparkContext {
     assert(sample.size === checkSample.size)
     for (i <- 0 until sample.size) assert(sample(i) === checkSample(i))
   }
+
+  test("top with predefined ordering") {
+    sc = new SparkContext("local", "test")
+    val nums = Array.range(1, 100000)
+    val ints = sc.makeRDD(scala.util.Random.shuffle(nums), 2)
+    val topK = ints.top(5)
+    assert(topK.size === 5)
+    assert(topK.sorted === nums.sorted.takeRight(5))
+  }
+
+  test("top with custom ordering") {
+    sc = new SparkContext("local", "test")
+    val words = Vector("a", "b", "c", "d")
+    implicit val ord = implicitly[Ordering[String]].reverse
+    val rdd = sc.makeRDD(words, 2)
+    val topK = rdd.top(2)
+    assert(topK.size === 2)
+    assert(topK.sorted === Array("b", "a"))
+  }
 }


### PR DESCRIPTION
This pull request contains an implementation for a new top K operation for an RDD[T] based on a specific Ordering[T]. This operation should be a more performant alternative to the usual first `sortByKey` and then `take(k)` for large data sets to avoid shuffling. The implementation currently relies on `mapPartitions`. I am not sure if there is a better approach, so it would be great to have other people look at it. Note that I am using Java's PriorityQueue because Scala's PriorityQueue currently has serialization issues (a bug has been filed already on Scala's version). 
