### PR TITLE
Fixed maven build without netty fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <java.version>1.5</java.version>
     <scala.version>2.10</scala.version>
     <mesos.version>0.9.0-incubating</mesos.version>
-    <akka.version>2.1.2</akka.version>
+    <akka.version>2.1.4</akka.version>
     <spray.version>1.1-M7</spray.version>
     <spray.json.version>1.2.3</spray.json.version>
     <slf4j.version>1.6.1</slf4j.version>
@@ -265,12 +265,12 @@
       <dependency>
         <groupId>org.scala-lang</groupId>
         <artifactId>scala-compiler</artifactId>
-        <version>${scala.version}</version>
+        <version>2.10.0</version>
       </dependency>
       <dependency>
         <groupId>org.scala-lang</groupId>
         <artifactId>jline</artifactId>
-        <version>${scala.version}</version>
+        <version>2.10.0</version>
       </dependency>
 
       <dependency>

--- a/repl/pom.xml
+++ b/repl/pom.xml
@@ -27,10 +27,12 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-compiler</artifactId>
+      <version>2.10.0</version>
     </dependency>
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>jline</artifactId>
+      <version>2.10.0</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
It was a quick fix though. Excluding netty everywhere in poms will make them look uglier. 

Maybe there exists a smarter solution to that. 
