### PR TITLE
Support Cancellation of Spark Jobs

### DIFF
--- a/core/src/main/scala/spark/InterruptibleIterator.scala
+++ b/core/src/main/scala/spark/InterruptibleIterator.scala
@@ -1,0 +1,26 @@
+package spark
+
+trait InterruptibleIterator[+T] extends  Iterator[T]{
+
+  override def hasNext(): Boolean = {
+    if (!Thread.currentThread().isInterrupted()) {
+      true
+    } else {
+      throw new InterruptedException ("Thread interrupted during RDD iteration")
+    }
+  }
+
+}
+
+class InterruptibleIteratorDecorator[T](delegate: Iterator[T])
+	extends AnyRef with InterruptibleIterator[T] {
+  
+  override def hasNext(): Boolean = {
+    super.hasNext
+    delegate.hasNext
+  }
+  
+  override def next(): T = {
+    delegate.next()
+  }
+}

--- a/core/src/main/scala/spark/RDD.scala
+++ b/core/src/main/scala/spark/RDD.scala
@@ -81,7 +81,12 @@ abstract class RDD[T: ClassManifest](
   // =======================================================================
 
   /** Implemented by subclasses to compute a given partition. */
-  def compute(split: Partition, context: TaskContext): Iterator[T]
+  protected def compute(split: Partition, context: TaskContext): Iterator[T]
+  
+  def computeInterruptibly(split: Partition, context: TaskContext): Iterator[T]	= {
+    val iter = compute(split, context)
+    new InterruptibleIteratorDecorator(iter)
+  }
 
   /**
    * Implemented by subclasses to return the set of partitions in this RDD. This method will only
@@ -229,7 +234,7 @@ abstract class RDD[T: ClassManifest](
     if (isCheckpointed) {
       firstParent[T].iterator(split, context)
     } else {
-      compute(split, context)
+      computeInterruptibly(split, context)
     }
   }
 

--- a/core/src/main/scala/spark/SparkContext.scala
+++ b/core/src/main/scala/spark/SparkContext.scala
@@ -617,6 +617,10 @@ class SparkContext(
     }
   }
 
+  def killJob(jobId: Int, reason: String="") {
+    dagScheduler.killJob(jobId, reason)
+  }
+
   /**
    * Run a function on a given set of partitions in an RDD and pass the results to the given
    * handler function. This is the main entry point for all actions in Spark. The allowLocal

--- a/core/src/main/scala/spark/executor/StandaloneExecutorBackend.scala
+++ b/core/src/main/scala/spark/executor/StandaloneExecutorBackend.scala
@@ -55,6 +55,12 @@ private[spark] class StandaloneExecutorBackend(
       } else {
         executor.launchTask(this, taskDesc.taskId, taskDesc.serializedTask)
       }
+    
+    case KillTask(taskId, executorId) => 
+      logInfo("Killing Task %s %s".format(taskId, executorId))
+      if (executor != null) {
+        executor.killTask(this, taskId, executorId)
+      }
 
     case Terminated(_) | RemoteClientDisconnected(_, _) | RemoteClientShutdown(_, _) =>
       logError("Driver terminated or disconnected! Shutting down.")

--- a/core/src/main/scala/spark/scheduler/ResultTask.scala
+++ b/core/src/main/scala/spark/scheduler/ResultTask.scala
@@ -77,7 +77,7 @@ private[spark] class ResultTask[T, U](
     preferredLocs.foreach (hostPort => Utils.checkHost(Utils.parseHostPort(hostPort)._1, "preferredLocs : " + preferredLocs))
   }
 
-  override def run(attemptId: Long): U = {
+  override def runInterruptibly(attemptId: Long): U = {
     val context = new TaskContext(stageId, partition, attemptId)
     metrics = Some(context.taskMetrics)
     try {

--- a/core/src/main/scala/spark/scheduler/TaskScheduler.scala
+++ b/core/src/main/scala/spark/scheduler/TaskScheduler.scala
@@ -19,6 +19,8 @@ private[spark] trait TaskScheduler {
 
   // Submit a sequence of tasks to run.
   def submitTasks(taskSet: TaskSet): Unit
+  
+  def killTasks(stageId: Int): Unit
 
   // Set a listener for upcalls. This is guaranteed to be set before submitTasks is called.
   def setListener(listener: TaskSchedulerListener): Unit

--- a/core/src/main/scala/spark/scheduler/TaskSet.scala
+++ b/core/src/main/scala/spark/scheduler/TaskSet.scala
@@ -15,4 +15,10 @@ private[spark] class TaskSet(
     val id: String = stageId + "." + attempt
 
   override def toString: String = "TaskSet " + id
+  
+  def kill() = {
+    tasks.foreach {
+      _.kill()
+    }
+  }
 }

--- a/core/src/main/scala/spark/scheduler/cluster/ClusterScheduler.scala
+++ b/core/src/main/scala/spark/scheduler/cluster/ClusterScheduler.scala
@@ -199,6 +199,24 @@ private[spark] class ClusterScheduler(val sc: SparkContext)
     backend.reviveOffers()
   }
 
+  override def killTasks(stageId: Int) {
+    synchronized {
+      schedulableBuilder.popTaskSetManagers(stageId).foreach { 
+        t =>
+         val ts = t.asInstanceOf[TaskSetManager].taskSet
+         ts.kill()
+         val taskIds = taskSetTaskIds(ts.id)
+         taskIds.foreach {
+           tid => 
+             val execId = taskIdToExecutorId(tid)
+             backend.killTask(tid, execId)
+         }
+      }
+      
+    }
+    
+  }
+
   def taskSetFinished(manager: TaskSetManager) {
     this.synchronized {
       activeTaskSets -= manager.taskSet.id

--- a/core/src/main/scala/spark/scheduler/cluster/SchedulerBackend.scala
+++ b/core/src/main/scala/spark/scheduler/cluster/SchedulerBackend.scala
@@ -10,6 +10,7 @@ import spark.Utils
 private[spark] trait SchedulerBackend {
   def start(): Unit
   def stop(): Unit
+  def killTask(taskId: Long, executorId: String): Unit
   def reviveOffers(): Unit
   def defaultParallelism(): Int
 
@@ -22,6 +23,4 @@ private[spark] trait SchedulerBackend {
       .getOrElse(512)
   }
 
-
-  // TODO: Probably want to add a killTask too
 }

--- a/core/src/main/scala/spark/scheduler/cluster/StandaloneClusterMessage.scala
+++ b/core/src/main/scala/spark/scheduler/cluster/StandaloneClusterMessage.scala
@@ -10,6 +10,7 @@ private[spark] sealed trait StandaloneClusterMessage extends Serializable
 // Driver to executors
 private[spark]
 case class LaunchTask(task: TaskDescription) extends StandaloneClusterMessage
+case class KillTask(taskId: Long, executorId: String) extends StandaloneClusterMessage
 
 private[spark]
 case class RegisteredExecutor(sparkProperties: Seq[(String, String)])

--- a/core/src/main/scala/spark/scheduler/local/LocalScheduler.scala
+++ b/core/src/main/scala/spark/scheduler/local/LocalScheduler.scala
@@ -100,6 +100,15 @@ private[spark] class LocalScheduler(threads: Int, val maxFailures: Int, val sc: 
       localActor ! LocalReviveOffers
     }
   }
+  
+  override def killTasks(stageId: Int) {
+    synchronized {
+      schedulableBuilder.popTaskSetManagers(stageId).foreach {
+        _.asInstanceOf[TaskSetManager].taskSet.kill()
+      }
+      
+    }
+  }
 
   def resourceOffer(freeCores: Int): Seq[TaskDescription] = {
     synchronized {

--- a/core/src/main/scala/spark/scheduler/mesos/CoarseMesosSchedulerBackend.scala
+++ b/core/src/main/scala/spark/scheduler/mesos/CoarseMesosSchedulerBackend.scala
@@ -130,6 +130,8 @@ private[spark] class CoarseMesosSchedulerBackend(
   override def disconnected(d: SchedulerDriver) {}
 
   override def reregistered(d: SchedulerDriver, masterInfo: MasterInfo) {}
+  
+  override def killTask(taskId: Long, executorId: String) {}
 
   /**
    * Method called by Mesos to offer resources on slaves. We respond by launching an executor,

--- a/core/src/main/scala/spark/scheduler/mesos/MesosSchedulerBackend.scala
+++ b/core/src/main/scala/spark/scheduler/mesos/MesosSchedulerBackend.scala
@@ -135,6 +135,8 @@ private[spark] class MesosSchedulerBackend(
   override def disconnected(d: SchedulerDriver) {}
 
   override def reregistered(d: SchedulerDriver, masterInfo: MasterInfo) {}
+  
+  def killTask(taskId: Long, executorId: String): Unit = {}
 
   /**
    * Method called by Mesos to offer resources on slaves. We resond by asking our active task sets

--- a/core/src/main/scala/spark/util/CompletionIterator.scala
+++ b/core/src/main/scala/spark/util/CompletionIterator.scala
@@ -1,12 +1,14 @@
 package spark.util
 
+import spark.InterruptibleIterator
+
 /**
  * Wrapper around an iterator which calls a completion method after it successfully iterates through all the elements
  */
-abstract class CompletionIterator[+A, +I <: Iterator[A]](sub: I) extends Iterator[A]{
-  def next = sub.next
-  def hasNext = {
-    val r = sub.hasNext
+abstract class CompletionIterator[+A, +I <: Iterator[A]](sub: I) extends InterruptibleIterator[A]{
+  override def next = sub.next
+  override def hasNext = {
+    val r = super.hasNext && sub.hasNext
     if (!r) {
       completion
     }

--- a/core/src/main/scala/spark/util/NextIterator.scala
+++ b/core/src/main/scala/spark/util/NextIterator.scala
@@ -1,7 +1,9 @@
 package spark.util
 
+import spark.InterruptibleIterator
+
 /** Provides a basic/boilerplate Iterator implementation. */
-private[spark] abstract class NextIterator[U] extends Iterator[U] {
+private[spark] abstract class NextIterator[U] extends InterruptibleIterator[U] {
   
   private var gotNext = false
   private var nextValue: U = _
@@ -49,6 +51,14 @@ private[spark] abstract class NextIterator[U] extends Iterator[U] {
   }
 
   override def hasNext: Boolean = {
+    try {
+      super.hasNext
+    } catch {
+      case e: Exception => {
+        closeIfNeeded
+        throw e;
+      }
+    }
     if (!finished) {
       if (!gotNext) {
         nextValue = getNext()

--- a/core/src/test/scala/spark/CancellationSuite.scala
+++ b/core/src/test/scala/spark/CancellationSuite.scala
@@ -1,0 +1,79 @@
+package spark
+
+import java.util.concurrent.{Callable, CountDownLatch, Future, FutureTask, TimeUnit}
+import scala.concurrent.ops.spawn
+import org.scalatest.BeforeAndAfter
+import org.scalatest.FunSuite
+import spark.scheduler.Task
+
+class CancellationSuite extends FunSuite with BeforeAndAfter {
+
+  test("Cancel Task") {
+    val latch = new CountDownLatch(2)
+    val startLatch = new CountDownLatch(1)
+    val task = new Task[Int](0) {
+      override def run(attemptId: Long) = {
+        try {
+          startLatch.countDown()
+          super.run(attemptId)
+        } catch {
+        	//check if interrupted exception is thrown
+        	case e: InterruptedException => latch.countDown()
+        }
+        0
+      }
+      override def runInterruptibly(attemptId: Long) = {
+        //check if interrupt is propagated
+        while(!Thread.currentThread().isInterrupted()) {}
+        latch.countDown()
+        0
+      }
+    }
+    spawn {
+      task.run(0)
+    }
+    startLatch.await()
+    Thread.sleep(100)
+    task.kill
+    val v = latch.await(5,TimeUnit.SECONDS)
+    assert(latch.getCount() == 0 && v)
+  }
+  test("handle interrupt during iteration") {
+    val latch = new CountDownLatch(1)
+    val innerLatch = new CountDownLatch(1)
+    val iter = new Iterator[Int] with InterruptibleIterator[Int] {
+      override def hasNext(): Boolean = super.hasNext && true
+      override def next(): Int = 0
+    }
+    val f = new FutureTask(new Callable[Int]{
+      override def call(): Int = {
+        var count=0
+        latch.countDown()
+        try{
+          while (iter.hasNext) {
+            count += iter.next
+          }
+        } finally {
+          innerLatch.countDown()
+        }
+        count
+      }
+    })
+    spawn {
+      latch.await()
+      Thread.sleep(100)
+      f.cancel(true)
+    }
+    f.run()
+    try {
+      f.get()
+    } catch {
+      case e: InterruptedException => {
+        innerLatch.await(1, TimeUnit.SECONDS)
+      }
+    } finally {
+      assert(innerLatch.getCount() == 0)
+    }
+  }
+
+}

--- a/core/src/test/scala/spark/CancellationSuite.scala
+++ b/core/src/test/scala/spark/CancellationSuite.scala
@@ -18,7 +18,7 @@ class CancellationSuite extends FunSuite with BeforeAndAfter {
           super.run(attemptId)
         } catch {
         	//check if interrupted exception is thrown
-        	case e: InterruptedException => latch.countDown()
+        	case e: Exception => latch.countDown()
         }
         0
       }
@@ -68,7 +68,7 @@ class CancellationSuite extends FunSuite with BeforeAndAfter {
     try {
       f.get()
     } catch {
-      case e: InterruptedException => {
+      case e: Exception => {
         innerLatch.await(1, TimeUnit.SECONDS)
       }
     } finally {

--- a/core/src/test/scala/spark/scheduler/ClusterSchedulerSuite.scala
+++ b/core/src/test/scala/spark/scheduler/ClusterSchedulerSuite.scala
@@ -83,9 +83,10 @@ class DummyTaskSetManager(
 
 class DummyTask(stageId: Int) extends Task[Int](stageId)
 {
-  def run(attemptId: Long): Int = {
+  def runInterruptibly(attemptId: Long): Int = {
     return 0
   }
+  
 }
 
 class ClusterSchedulerSuite extends FunSuite with LocalSparkContext with Logging {

--- a/core/src/test/scala/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/spark/scheduler/DAGSchedulerSuite.scala
@@ -48,6 +48,7 @@ class DAGSchedulerSuite extends FunSuite with BeforeAndAfter with LocalSparkCont
     }
     override def setListener(listener: TaskSchedulerListener) = {}
     override def defaultParallelism() = 2
+    override def killTasks(stageId: Int) = {}
   }
 
   var mapOutputTracker: MapOutputTracker = null


### PR DESCRIPTION
Hi

This patch allows us to cancel runaway Spark queries by issuing a killJob command passing in the jobId. The approach taken here is to let the DAG scheduler clean up its state about a job that is currently executing, and propagate an interrupt to the running task. Each task runs within a Future to properly respond to interrupts and cancel execution. Every Iterator that iterates over data (either via CacheManager/ or BlockFetcher or the HadoopRDD) is wrapped by an InterruptibleIterator which checks for the interrupt and cleans up state accordingly and exits.
I have tested the performance of this patch against master on a bunch of internal queries and the performance is not impacted by this patch.
I am in the process of obtaining TPCH benchmarks with and without the patch which i will attach here.
In the meanwhile, please review and let me know if the design needs changes.
