### PR TITLE
Fixed major performance bug in Network Receiver

### DIFF
--- a/streaming/src/main/scala/spark/streaming/receivers/ActorReceiver.scala
+++ b/streaming/src/main/scala/spark/streaming/receivers/ActorReceiver.scala
@@ -9,6 +9,8 @@ import spark.streaming.dstream.NetworkReceiver
 
 import java.util.concurrent.atomic.AtomicInteger
 
+import scala.collection.mutable.ArrayBuffer
+
 /** A helper with set of defaults for supervisor strategy **/
 object ReceiverSupervisorStrategy {
 
@@ -136,8 +138,9 @@ private[streaming] class ActorReceiver[T: ClassManifest](
   }
 
   protected def pushBlock(iter: Iterator[T]) {
-    pushBlock("block-" + streamId + "-" + System.nanoTime(),
-      iter, null, storageLevel)
+    val buffer = new ArrayBuffer[T]
+    buffer ++= iter
+    pushBlock("block-" + streamId + "-" + System.nanoTime(), buffer, null, storageLevel)
   }
 
   protected def onStart() = {


### PR DESCRIPTION
The data received with NetworkReceiver.BlockGenerator into an ArrayBuffer which was then copied twice into 2 new ArrayBuffer unnecessarily, before being stored in the BlockManager. This was partially due to the use of BlockManager.put with iterator method, even though the BlockManager.put with ArrayBuffer exists. This bug affects almost all the receivers. I havent tested how much performance improvement in data ingestion rate would one get with this fix, but since its such an obvious fix and I want the fix go into 0.7.3 immediately, I am requesting this to be accepted. 
