### PR TITLE
Remove active job from idToActiveJob when job finished or aborted

### DIFF
--- a/core/src/main/scala/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/spark/scheduler/DAGScheduler.scala
@@ -524,6 +524,7 @@ class DAGScheduler(
                   job.numFinished += 1
                   // If the whole job has finished, remove it
                   if (job.numFinished == job.numPartitions) {
+                    idToActiveJob -= stage.priority
                     activeJobs -= job
                     resultStageToJob -= stage
                     markStageAsFinished(stage)
@@ -671,6 +672,7 @@ class DAGScheduler(
       val error = new SparkException("Job failed: " + reason)
       job.listener.jobFailed(error)
       sparkListeners.foreach(_.onJobEnd(SparkListenerJobEnd(job, JobFailed(error))))
+      idToActiveJob -= resultStage.priority
       activeJobs -= job
       resultStageToJob -= resultStage
     }


### PR DESCRIPTION
This commit can fix the issue SPARK-793. And our team have tried it on Yarn cluster.
![6471ad85-e4ed-4946-919e-6844941757e0](https://f.cloud.github.com/assets/1321044/757008/bbff1592-e663-11e2-92b0-57838d604c24.png)
