### PR TITLE
Fixed SPARK-795 with explicit dependencies

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -58,12 +58,10 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scalap</artifactId>
-      <version>2.9.3</version>
     </dependency>
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>2.9.3</version>
     </dependency>
     <dependency>
       <groupId>net.liftweb</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -56,6 +56,16 @@
       <artifactId>akka-slf4j</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scalap</artifactId>
+      <version>2.9.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>2.9.3</version>
+    </dependency>
+    <dependency>
       <groupId>net.liftweb</groupId>
       <artifactId>lift-json_2.9.2</artifactId>
     </dependency>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -18,7 +18,6 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>2.9.3</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -16,6 +16,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>2.9.3</version>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,16 @@
         <artifactId>jline</artifactId>
         <version>${scala.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.scala-lang</groupId>
+        <artifactId>scala-library</artifactId>
+        <version>${scala.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.scala-lang</groupId>
+        <artifactId>scalap</artifactId>
+        <version>${scala.version}</version>
+      </dependency>
 
       <dependency>
         <groupId>log4j</groupId>

--- a/streaming/pom.xml
+++ b/streaming/pom.xml
@@ -61,7 +61,6 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>2.9.3</version>
     </dependency>
     <dependency>
       <groupId>com.typesafe.akka</groupId>

--- a/streaming/pom.xml
+++ b/streaming/pom.xml
@@ -59,6 +59,11 @@
       <version>3.0.3</version>
     </dependency>
     <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>2.9.3</version>
+    </dependency>
+    <dependency>
       <groupId>com.typesafe.akka</groupId>
       <artifactId>akka-zeromq</artifactId>
       <version>2.0.3</version>


### PR DESCRIPTION
Without explicit dependencies for 2.9.3 versions of scala-library and scalap, packages built against Scala 2.9.2 can pull in 2.9.2 versions of scala-compiler, scala-library, scalap, etc. which get resolved by maven ahead of the 2.9.3 versions.  This PR is sufficient to make sure that lift-json_2.9.2, akka 2.0.3, etc. don't get a chance to bring in these 2.9.2 transitive dependencies.

The specific problem of SPARK-795 was a result of Patrick's new UI code using scala.util.Try, which was first introduced in Scala 2.9.3 -- and obviously could not be found when scala-library 2.9.2 was resolved.
