### PR TITLE
Pass executor env vars (e.g. SPARK_CLASSPATH) to compute-classpath.sh

### DIFF
--- a/core/src/main/scala/spark/deploy/worker/ExecutorRunner.scala
+++ b/core/src/main/scala/spark/deploy/worker/ExecutorRunner.scala
@@ -98,7 +98,9 @@ private[spark] class ExecutorRunner(
 
     // Figure out our classpath with the external compute-classpath script
     val ext = if (System.getProperty("os.name").startsWith("Windows")) ".cmd" else ".sh"
-    val classPath = Utils.executeAndGetOutput(Seq(sparkHome + "/bin/compute-classpath" + ext))
+    val classPath = Utils.executeAndGetOutput(
+        Seq(sparkHome + "/bin/compute-classpath" + ext),
+        extraEnvironment=appDesc.command.environment)
 
     Seq("-cp", classPath) ++ libraryOpts ++ userOpts ++ memoryOpts
   }


### PR DESCRIPTION
ExecutorRunner passes environment variables (specified at the driver) to the executed java program, but not to bin/compute-classpath. This means that env. vars. like SPARK_CLASSPATH aren't passed to workers from the driver, making them not work as per-job configuration.
