### PR TITLE
changing com.google.code.findbugs maven coordinates

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -144,7 +144,7 @@ object SparkBuild extends Build {
 
     libraryDependencies ++= Seq(
       "com.google.guava" % "guava" % "14.0.1",
-      "com.google.code.findbugs" % "jsr305" % "1.3.+",
+      "com.google.code.findbugs" % "jsr305" % "1.3.9",
       "log4j" % "log4j" % "1.2.16",
       "org.slf4j" % "slf4j-api" % slf4jVersion,
       "org.slf4j" % "slf4j-log4j12" % slf4jVersion,


### PR DESCRIPTION
"1.3.+" isn't in the public maven repository. Spark compiles fine as it finds it in the resolver list.  However, I did a local-publish and noticed that my drivers would no longer compile. This is the error I would see:

Access denied to: https://oss.sonatype.org/service/local/staging/deploy/maven2/com/google/code/findbugs/jsr305/1.3.+/jsr305-1.3.+.pom

Changing it to 1.3.9 fixes the driver compile issue.
