### PR TITLE
Adds app name in HTML page titles on job web UI

### DIFF
--- a/core/src/main/scala/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/spark/ui/UIUtils.scala
@@ -31,7 +31,7 @@ private[spark] object UIUtils {
         <link rel="stylesheet" href="/static/webui.css" type="text/css" />
         <link rel="stylesheet" href="/static/bootstrap-responsive.min.css" type="text/css" />
         <script src="/static/sorttable.js"></script>
-        <title>{title}</title>
+        <title>{sc.appName} - {title}</title>
         <style type="text/css">
           table.sortable thead {{ cursor: pointer; }}
         </style>


### PR DESCRIPTION
This adds the app name to HTML page titles on the job web UI and should fix [SPARK-806](https://spark-project.atlassian.net/browse/SPARK-802).
![environment](https://f.cloud.github.com/assets/4754931/800044/7175917a-ed81-11e2-98e7-97f9fb9be907.png)
![spark pages](https://f.cloud.github.com/assets/4754931/800045/7176fb64-ed81-11e2-9af7-22e676936803.png)
![spark storage](https://f.cloud.github.com/assets/4754931/800046/71878cb8-ed81-11e2-919b-999d287b4562.png)
