### PR TITLE
Add tgz option to make-distribution.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ dependency-reduced-pom.xml
 .ensime_lucene
 checkpoint
 derby.log
+dist/
+spark-*-bin.tar.gz


### PR DESCRIPTION
This pull request builds on #662 by adding a tgz flag.  ie- `./make-distribution.sh tgz`  When tgz is given a spark-$VERSION-bin.tar.gz file will be generated from the dist/ directory.

Use cases for this functionality:
- We have many spark environments and use chef to manage deploys and configs.  Using this method we can easily deploy/undeploy/re-deploy spark from a .tar.gz in a few seconds.
- Should make generating binary releases easy
