### PR TITLE
Fix bug preventing defaultMinSplits from being set >2 (SPARK-822)

### DIFF
--- a/core/src/main/scala/spark/SparkContext.scala
+++ b/core/src/main/scala/spark/SparkContext.scala
@@ -772,7 +772,7 @@ class SparkContext(
   def defaultParallelism: Int = taskScheduler.defaultParallelism
 
   /** Default min number of partitions for Hadoop RDDs when not given by user */
-  def defaultMinSplits: Int = math.min(defaultParallelism, 2)
+  def defaultMinSplits: Int = math.max(defaultParallelism, 2)
 
   private var nextShuffleId = new AtomicInteger(0)
 

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -122,6 +122,13 @@ class SparkContext(object):
         """
         return self._jsc.sc().defaultParallelism()
 
+    @property
+    def defaultMinSplits(self):
+        """
+        Default min number of partitions for Hadoop RDDs when not given by user
+        """
+        return self._jsc.sc().defaultMinSplits()
+
     def __del__(self):
         self.stop()
 
@@ -162,7 +169,7 @@ class SparkContext(object):
         nodes), or any Hadoop-supported file system URI, and return it as an
         RDD of Strings.
         """
-        minSplits = minSplits or min(self.defaultParallelism, 2)
+        minSplits = minSplits or self.defaultMinSplits
         jrdd = self._jsc.textFile(name, minSplits)
         return RDD(jrdd, self)
 


### PR DESCRIPTION
This fixes [SPARK-822](https://spark-project.atlassian.net/browse/SPARK-822), an issue where defaultMinSplits would be capped at 2 even if `spark.default.parallelism` was set higher.  This could cause jobs to not use enough parallelism if they used the default settings.

The problem was the use of `min` instead of `max`.
