### PR TITLE
Fix two small usability issues

### DIFF
--- a/core/src/main/scala/spark/deploy/client/Client.scala
+++ b/core/src/main/scala/spark/deploy/client/Client.scala
@@ -135,7 +135,7 @@ private[spark] class Client(
         Await.result(future, timeout)
       } catch {
         case e: TimeoutException =>
-          logInfo("Close request to Master timed out; it may already be shut down.")
+          logInfo("Stop request to Master timed out; it may already be shut down.")
       }
       actor = null
     }

--- a/core/src/main/scala/spark/deploy/client/Client.scala
+++ b/core/src/main/scala/spark/deploy/client/Client.scala
@@ -22,7 +22,7 @@ import akka.actor._
 import akka.pattern.ask
 import akka.util.Duration
 import akka.util.duration._
-import akka.pattern.AskTimeoutException
+import java.util.concurrent.TimeoutException
 import spark.{SparkException, Logging}
 import akka.remote.RemoteClientLifeCycleEvent
 import akka.remote.RemoteClientShutdown
@@ -134,7 +134,8 @@ private[spark] class Client(
         val future = actor.ask(StopClient)(timeout)
         Await.result(future, timeout)
       } catch {
-        case e: AskTimeoutException =>  // Ignore it, maybe master went away
+        case e: TimeoutException =>
+          logInfo("Close request to Master timed out; it may already be shut down.")
       }
       actor = null
     }

--- a/core/src/main/scala/spark/scheduler/cluster/ClusterTaskSetManager.scala
+++ b/core/src/main/scala/spark/scheduler/cluster/ClusterTaskSetManager.scala
@@ -564,8 +564,8 @@ private[spark] class ClusterTaskSetManager(sched: ClusterScheduler, val taskSet:
     decreaseRunningTasks(1)
     if (!finished(index)) {
       tasksFinished += 1
-      logInfo("Finished TID %s in %d ms (progress: %d/%d)".format(
-        tid, info.duration, tasksFinished, numTasks))
+      logInfo("Finished TID %s in %d ms on %s (progress: %d/%d)".format(
+        tid, info.duration, info.hostPort, tasksFinished, numTasks))
       // Deserialize task result and pass it to the scheduler
       try {
         val result = ser.deserialize[TaskResult[_]](serializedData)


### PR DESCRIPTION
This fixes two issues reported by @rxin.
1. We expand an exception catch scope to include an exception that can occur in Client.scala
2. We log the `host:port` of the executor when a tasks finishes.
