### PR TITLE
made SimpleUpdater consistent with other updaters

### DIFF
--- a/mllib/src/main/scala/spark/mllib/optimization/Updater.scala
+++ b/mllib/src/main/scala/spark/mllib/optimization/Updater.scala
@@ -41,7 +41,8 @@ abstract class Updater extends Serializable {
 class SimpleUpdater extends Updater {
   override def compute(weightsOld: DoubleMatrix, gradient: DoubleMatrix,
       stepSize: Double, iter: Int, regParam: Double): (DoubleMatrix, Double) = {
-    val normGradient = gradient.mul(stepSize / math.sqrt(iter))
+    val thisIterStepSize = stepSize / math.sqrt(iter)
+    val normGradient = gradient.mul(thisIterStepSize)
     (weightsOld.sub(normGradient), 0)
   }
 }


### PR DESCRIPTION
@shivaram, @etrain: It seemed more complicated (and more lines of code) to have L1 and L2 updaters extend SimpleUpdater, so I made this small change instead to make the code a bit more readable.
