### PR TITLE
Add Spark multi-user support for standalone mode

### DIFF
--- a/core/src/hadoop2-yarn/scala/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/hadoop2-yarn/scala/spark/deploy/SparkHadoopUtil.scala
@@ -48,6 +48,8 @@ object SparkHadoopUtil {
     func(args)
   }
 
+  def createSerializedToken(): Option[String] = None
+
   // Note that all params which start with SPARK are propagated all the way through, so if in yarn mode, this MUST be set to true.
   def isYarnMode(): Boolean = {
     val yarnMode = System.getProperty("SPARK_YARN_MODE", System.getenv("SPARK_YARN_MODE"))

--- a/core/src/hadoop2/scala/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/hadoop2/scala/spark/deploy/SparkHadoopUtil.scala
@@ -16,14 +16,23 @@
  */
 
 package spark.deploy
-import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.mapred.JobConf
 
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.FileSystem
+import org.apache.hadoop.mapred.JobConf
+import org.apache.hadoop.security.UserGroupInformation
+import org.apache.hadoop.security.token.{Token, TokenIdentifier}
+
+import java.io.IOException
+import java.security.PrivilegedExceptionAction
 
 /**
  * Contains util methods to interact with Hadoop from spark.
  */
 object SparkHadoopUtil {
+  val HDFS_TOKEN_KEY = "SPARK_HDFS_TOKEN"
+  val conf = newConfiguration()
+  UserGroupInformation.setConfiguration(conf)
 
   def getUserNameFromEnvironment(): String = {
     // defaulting to -D ...
@@ -31,9 +40,39 @@ object SparkHadoopUtil {
   }
 
   def runAsUser(func: (Product) => Unit, args: Product) {
+    runAsUser(func, args, getUserNameFromEnvironment())
+  }
 
-    // Add support, if exists - for now, simply run func !
-    func(args)
+  def runAsUser(func: (Product) => Unit, args: Product, user: String) {
+    val ugi = UserGroupInformation.createRemoteUser(user)
+    if (UserGroupInformation.isSecurityEnabled) {
+      Option(System.getenv(HDFS_TOKEN_KEY)) match {
+        case Some(s) =>
+          ugi.setAuthenticationMethod(UserGroupInformation.AuthenticationMethod.TOKEN)
+          val token = new Token[TokenIdentifier]()
+          token.decodeFromUrlString(s)
+          ugi.addToken(token)
+        case None => throw new IOException("Failed to get token in security environment")
+
+      }
+    }
+
+    ugi.doAs(new PrivilegedExceptionAction[Unit] {
+      def run: Unit = {
+        func(args)
+      }
+    })
+  }
+
+  def createSerializedToken(): Option[String] = {
+    if (UserGroupInformation.isSecurityEnabled) {
+      val fs = FileSystem.get(conf)
+      val user = UserGroupInformation.getCurrentUser.getShortUserName
+      Option(fs.getDelegationToken(user).asInstanceOf[Token[_ <: TokenIdentifier]])
+        .map(_.encodeToUrlString())
+    } else {
+      None
+    }
   }
 
   // Return an appropriate (subclass) of Configuration. Creating config can initializes some hadoop subsystems
@@ -43,5 +82,4 @@ object SparkHadoopUtil {
   def addCredentials(conf: JobConf) {}
 
   def isYarnMode(): Boolean = { false }
-
 }

--- a/core/src/main/scala/spark/SparkContext.scala
+++ b/core/src/main/scala/spark/SparkContext.scala
@@ -53,7 +53,6 @@ import org.apache.hadoop.mapred.TextInputFormat
 import org.apache.hadoop.mapreduce.{InputFormat => NewInputFormat}
 import org.apache.hadoop.mapreduce.{Job => NewHadoopJob}
 import org.apache.hadoop.mapreduce.lib.input.{FileInputFormat => NewFileInputFormat}
-import org.apache.hadoop.security.UserGroupInformation
 
 import org.apache.mesos.MesosNativeLibrary
 
@@ -143,6 +142,11 @@ class SparkContext(
   executorEnvs("SPARK_MEM") = SparkContext.executorMemoryRequested + "m"
   if (environment != null) {
     executorEnvs ++= environment
+  }
+
+  // Add token to environment variables to pass to executors for security Hadoop access
+  SparkHadoopUtil.createSerializedToken() map { e =>
+    executorEnvs(SparkHadoopUtil.HDFS_TOKEN_KEY) = e
   }
 
   // Create and start the scheduler

--- a/core/src/main/scala/spark/deploy/worker/ExecutorRunner.scala
+++ b/core/src/main/scala/spark/deploy/worker/ExecutorRunner.scala
@@ -91,6 +91,7 @@ private[spark] class ExecutorRunner(
     case "{{EXECUTOR_ID}}" => execId.toString
     case "{{HOSTNAME}}" => Utils.parseHostPort(hostPort)._1
     case "{{CORES}}" => cores.toString
+    case "{{USER}}" => appDesc.user
     case other => other
   }
 

--- a/core/src/main/scala/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
+++ b/core/src/main/scala/spark/scheduler/cluster/SparkDeploySchedulerBackend.scala
@@ -44,7 +44,7 @@ private[spark] class SparkDeploySchedulerBackend(
     val driverUrl = "akka://spark@%s:%s/user/%s".format(
       System.getProperty("spark.driver.host"), System.getProperty("spark.driver.port"),
       StandaloneSchedulerBackend.ACTOR_NAME)
-    val args = Seq(driverUrl, "{{EXECUTOR_ID}}", "{{HOSTNAME}}", "{{CORES}}")
+    val args = Seq(driverUrl, "{{EXECUTOR_ID}}", "{{HOSTNAME}}", "{{CORES}}", "{{USER}}")
     val command = Command("spark.executor.StandaloneExecutorBackend", args, sc.executorEnvs)
     val sparkHome = sc.getSparkHome().getOrElse(
       throw new IllegalArgumentException("must supply spark home for spark standalone"))


### PR DESCRIPTION
This patch add multi-user support for standalone mode. 

Currently Spark ExecutorBackend do not distinguish the user who submits app, instead it uses the user who start Spark cluster to communicate with hdfs, this will introduce file permission issue. This patch solves this issue in two aspects:
1. ExecutorBackend use the app's user to access hdfs, this will keep the same file permission with the app's user.
2. For security hdfs, client driver get delegation token and distribute to cluster, ExecutorBackend use delegation token to get service authentication and access hdfs.

I've tested it on CDH4.1.2, Hadoop 1.0.4 with or without security enabled, but I cannot cover other different versions.

This patch does not solve delegation token renew issue when communicate with security hadoop, for long-run apps like Spark Streaming, Shark Server, this will make access failure when delegation token expires.

Any advice about renew mechanism is really appreciated, I will add it in this patch.

Thanks
Jerry
