### PR TITLE
Clean up web UI page headers

### DIFF
--- a/core/src/main/scala/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/spark/ui/UIUtils.scala
@@ -74,7 +74,6 @@ private[spark] object UIUtils {
                     </ul>
                     <ul id="infolist">
                       <li>Application: <strong>{sc.appName}</strong></li>
-                      <li>Master: <strong>{sc.master}</strong></li>
                       <li>Executors: <strong>{sc.getExecutorStorageStatus.size}</strong></li>
                     </ul>
                   </div>
@@ -117,9 +116,9 @@ private[spark] object UIUtils {
               <img src="/static/spark_logo.png" />
             </div>
             <div class="span10">
-              <h1 style="vertical-align: bottom; margin-top: 40px; display: inline-block;">
+              <h2 style="vertical-align: bottom; margin-top: 40px; display: inline-block;">
                 {title}
-              </h1>
+              </h2>
             </div>
           </div>
           {content}

--- a/core/src/main/scala/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/spark/ui/UIUtils.scala
@@ -116,9 +116,9 @@ private[spark] object UIUtils {
               <img src="/static/spark_logo.png" />
             </div>
             <div class="span10">
-              <h2 style="vertical-align: bottom; margin-top: 40px; display: inline-block;">
+              <h3 style="vertical-align: bottom; margin-top: 40px; display: inline-block;">
                 {title}
-              </h2>
+              </h3>
             </div>
           </div>
           {content}


### PR DESCRIPTION
This removes the master URL from the job UI and reduces the heading size of basic Spark pages, fixing [SPARK-828](https://spark-project.atlassian.net/browse/SPARK-828).
![navbar](https://f.cloud.github.com/assets/4754931/888936/1c70467e-fa16-11e2-9e43-b9479c168f2d.png)
![heading after](https://f.cloud.github.com/assets/4754931/888938/1c9c4b5c-fa16-11e2-87fc-d0bcc2306f0d.png)
