### PR TITLE
Allow user to remove broadcast variables when they are no longer used

### DIFF
--- a/core/src/main/scala/spark/SparkContext.scala
+++ b/core/src/main/scala/spark/SparkContext.scala
@@ -483,7 +483,7 @@ class SparkContext(
    * Broadcast a read-only variable to the cluster, returning a [[spark.broadcast.Broadcast]] object for
    * reading it in distributed functions. The variable will be sent to each cluster only once.
    */
-  def broadcast[T](value: T) = env.broadcastManager.newBroadcast[T](value, isLocal)
+  def broadcast[T](value: T, tellMaster: Boolean = true) = env.broadcastManager.newBroadcast[T](value, isLocal, tellMaster)
 
   /**
    * Add a file to be downloaded with this Spark job on every node.

--- a/core/src/main/scala/spark/api/java/JavaSparkContext.scala
+++ b/core/src/main/scala/spark/api/java/JavaSparkContext.scala
@@ -308,7 +308,7 @@ class JavaSparkContext(val sc: SparkContext) extends JavaSparkContextVarargsWork
    * Broadcast a read-only variable to the cluster, returning a [[spark.Broadcast]] object for
    * reading it in distributed functions. The variable will be sent to each cluster only once.
    */
-  def broadcast[T](value: T): Broadcast[T] = sc.broadcast(value)
+  def broadcast[T](value: T, tellMaster: Boolean): Broadcast[T] = sc.broadcast(value, tellMaster)
 
   /** Shut down the SparkContext. */
   def stop() {

--- a/core/src/main/scala/spark/broadcast/Broadcast.scala
+++ b/core/src/main/scala/spark/broadcast/Broadcast.scala
@@ -15,7 +15,7 @@ abstract class Broadcast[T](private[spark] val id: Long) extends Serializable {
   
   // Remove a Broadcast blcok from the SparkContext and Executors that have it.
   // Set isClearSource true to also remove the Broadcast value from its source.
-  def rm(toClearSource: Boolean)
+  def remove(toReleaseSource: Boolean)
 }
 
 private[spark] 
@@ -49,9 +49,9 @@ class BroadcastManager(val _isDriver: Boolean) extends Logging with Serializable
   }
 
   private val nextBroadcastId = new AtomicLong(0)
-
-  def newBroadcast[T](value_ : T, isLocal: Boolean) =
-    broadcastFactory.newBroadcast[T](value_, isLocal, nextBroadcastId.getAndIncrement())
-
+  
+  def newBroadcast[T](value_ : T, isLocal: Boolean, tellMaster: Boolean) =
+    broadcastFactory.newBroadcast[T](value_, isLocal, nextBroadcastId.getAndIncrement(), tellMaster)
+  
   def isDriver = _isDriver
 }

--- a/core/src/main/scala/spark/broadcast/Broadcast.scala
+++ b/core/src/main/scala/spark/broadcast/Broadcast.scala
@@ -12,6 +12,10 @@ abstract class Broadcast[T](private[spark] val id: Long) extends Serializable {
   // readObject having to be 'private' in sub-classes.
 
   override def toString = "spark.Broadcast(" + id + ")"
+  
+  // Remove a Broadcast blcok from the SparkContext and Executors that have it.
+  // Set isClearSource true to also remove the Broadcast value from its source.
+  def rm(toClearSource: Boolean)
 }
 
 private[spark] 

--- a/core/src/main/scala/spark/broadcast/BroadcastFactory.scala
+++ b/core/src/main/scala/spark/broadcast/BroadcastFactory.scala
@@ -8,6 +8,6 @@ package spark.broadcast
  */
 private[spark] trait BroadcastFactory {
   def initialize(isDriver: Boolean): Unit
-  def newBroadcast[T](value: T, isLocal: Boolean, id: Long): Broadcast[T]
+  def newBroadcast[T](value: T, isLocal: Boolean, id: Long, tellMaster: Boolean): Broadcast[T]
   def stop(): Unit
 }

--- a/core/src/main/scala/spark/broadcast/TreeBroadcast.scala
+++ b/core/src/main/scala/spark/broadcast/TreeBroadcast.scala
@@ -10,7 +10,7 @@ import scala.math
 import spark._
 import spark.storage.StorageLevel
 
-private[spark] class TreeBroadcast[T](@transient var value_ : T, isLocal: Boolean, id: Long)
+private[spark] class TreeBroadcast[T](@transient var value_ : T, isLocal: Boolean, id: Long, tellMaster: Boolean)
 extends Broadcast[T](id) with Logging with Serializable {
 
   def value = value_
@@ -18,8 +18,9 @@ extends Broadcast[T](id) with Logging with Serializable {
   def blockId = "broadcast_" + id
 
   MultiTracker.synchronized {
-    //Let BlockManagerMaster know that we have the broadcast block for its latter notification us to remove.
-    SparkEnv.get.blockManager.putSingle(blockId, value_, StorageLevel.MEMORY_AND_DISK, true)
+    //If tellMaster is true, Let BlockManagerMaster know that we have the broadcast 
+    //block for its latter notification us to remove.
+    SparkEnv.get.blockManager.putSingle(blockId, value_, StorageLevel.MEMORY_AND_DISK, tellMaster)
   }
 
   @transient var arrayOfBlocks: Array[BroadcastBlock] = null
@@ -48,15 +49,19 @@ extends Broadcast[T](id) with Logging with Serializable {
     sendBroadcast()
   }
   
-  override def rm(toClearSource: Boolean = false) {
+  override def remove(toReleaseSource: Boolean = false) {
     logInfo("Remove broadcast variable " + blockId)
-    SparkEnv.get.blockManager.master.removeBlock(blockId)
+    if (tellMaster) {
+      logInfo("remove broadcast variable block" + blockId + " on slaves")
+      SparkEnv.get.blockManager.master.removeBlock(blockId)
+    }
     SparkEnv.get.blockManager.removeBlock(blockId, false)
-    if(toClearSource)
-      clearBlockSource()
+    if (toReleaseSource) {
+      releaseSource()
+    }
   }
   
-  def clearBlockSource(){
+  def releaseSource(){
     arrayOfBlocks = null
     listOfSources = null
     serveMR = null
@@ -130,8 +135,10 @@ extends Broadcast[T](id) with Logging with Serializable {
           val receptionSucceeded = receiveBroadcast(id)
           if (receptionSucceeded) {
             value_ = MultiTracker.unBlockifyObject[T](arrayOfBlocks, totalBytes, totalBlocks)
+            //If tellMaster is true, Let BlockManagerMaster know that we have the broadcast 
+            //block for its latter notification us to remove.
             SparkEnv.get.blockManager.putSingle(
-              blockId, value_, StorageLevel.MEMORY_AND_DISK, false)
+              blockId, value_, StorageLevel.MEMORY_AND_DISK, tellMaster)
           }  else {
             logError("Reading broadcast variable " + id + " failed")
           }
@@ -594,8 +601,8 @@ private[spark] class TreeBroadcastFactory
 extends BroadcastFactory {
   def initialize(isDriver: Boolean) { MultiTracker.initialize(isDriver) }
 
-  def newBroadcast[T](value_ : T, isLocal: Boolean, id: Long) =
-    new TreeBroadcast[T](value_, isLocal, id)
+  def newBroadcast[T](value_ : T, isLocal: Boolean, id: Long, tellMaster: Boolean) =
+    new TreeBroadcast[T](value_, isLocal, id, tellMaster)
 
   def stop() { MultiTracker.stop() }
 }

--- a/core/src/main/scala/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/spark/storage/BlockManager.scala
@@ -772,6 +772,13 @@ private[spark] class BlockManager(
   def getSingle(blockId: String): Option[Any] = {
     get(blockId).map(_.next())
   }
+  
+  /**
+   * Read a block consisting of a single object only from local BlockManager.
+   */
+  def getSingleLocal(blockId: String): Option[Any] = {
+    getLocal(blockId).map(_.next())
+  }
 
   /**
    * Write a block consisting of a single object.

--- a/examples/src/main/scala/spark/examples/BroadcastTest.scala
+++ b/examples/src/main/scala/spark/examples/BroadcastTest.scala
@@ -22,11 +22,11 @@ object BroadcastTest {
     for (i <- 0 until 2) {
       println("Iteration " + i)
       println("===========")
-      val barr1 = sc.broadcast(arr1)
+      val barr1 = sc.broadcast(arr1, (i == 0))
       sc.parallelize(1 to 10, slices).foreach {
         i => println(barr1.value.size)
       }
-      barr1.rm(true)
+      barr1.remove(true)
     }
 
     System.exit(0)

--- a/examples/src/main/scala/spark/examples/BroadcastTest.scala
+++ b/examples/src/main/scala/spark/examples/BroadcastTest.scala
@@ -26,6 +26,7 @@ object BroadcastTest {
       sc.parallelize(1 to 10, slices).foreach {
         i => println(barr1.value.size)
       }
+      barr1.rm(true)
     }
 
     System.exit(0)


### PR DESCRIPTION
In Spark, users can create broadcast variables to share read-only variables across tasks or operations,especially when they are large. However, the current Spark does not allow users to remove those variables in one SparkContext. This becomes a major issue for long running Shark servers which uses one SparkContext. To address this issue, this patch allows users to remove broadcast variables when they are no longer used. To remove a broadcast variable, users only need to call the Broadcast.rm(toClearSource:Boolean) methond, the broadcast variable across the slaves will be deleted. If toClearSource is set true, data source (e.g., file used by HttpServer) will be deleted too.
