### PR TITLE
Pull HBASE_VERSION in the head of sbt build

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -40,6 +40,9 @@ object SparkBuild extends Build {
   //val HADOOP_MAJOR_VERSION = "2"
   //val HADOOP_YARN = true
 
+  // HBase version jar thrown to lib_managed in this build; set as appropriate.
+  val HBASE_VERSION = "0.94.6"
+
   lazy val root = Project("root", file("."), settings = rootSettings) aggregate(core, repl, examples, bagel, streaming, mllib, tools)
 
   lazy val core = Project("core", file("core"), settings = coreSettings)
@@ -227,7 +230,7 @@ object SparkBuild extends Build {
     libraryDependencies ++= Seq(
       "com.twitter" % "algebird-core_2.9.2" % "0.1.11",
 
-      "org.apache.hbase" % "hbase" % "0.94.6" excludeAll(excludeNetty, excludeAsm),
+      "org.apache.hbase" % "hbase" % HBASE_VERSION excludeAll(excludeNetty, excludeAsm),
 
       "org.apache.cassandra" % "cassandra-all" % "1.2.5"
         exclude("com.google.guava", "guava")

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -40,7 +40,7 @@ object SparkBuild extends Build {
   //val HADOOP_MAJOR_VERSION = "2"
   //val HADOOP_YARN = true
 
-  // HBase version jar thrown to lib_managed in this build; set as appropriate.
+  // HBase version; set as appropriate.
   val HBASE_VERSION = "0.94.6"
 
   lazy val root = Project("root", file("."), settings = rootSettings) aggregate(core, repl, examples, bagel, streaming, mllib, tools)


### PR DESCRIPTION
Small nitpicking on SBT build as has been discussed on the list. Now that Spark pulls HBase jar and drops it into lib_managed, i think it should be far more obvious it does that, in the build. 
