### PR TITLE
Use new Configuration() instead of slower new JobConf() in SerializableWritable

### DIFF
--- a/core/src/main/scala/spark/SerializableWritable.scala
+++ b/core/src/main/scala/spark/SerializableWritable.scala
@@ -21,7 +21,7 @@ import java.io._
 
 import org.apache.hadoop.io.ObjectWritable
 import org.apache.hadoop.io.Writable
-import org.apache.hadoop.mapred.JobConf
+import org.apache.hadoop.conf.Configuration
 
 class SerializableWritable[T <: Writable](@transient var t: T) extends Serializable {
   def value = t
@@ -35,7 +35,7 @@ class SerializableWritable[T <: Writable](@transient var t: T) extends Serializa
   private def readObject(in: ObjectInputStream) {
     in.defaultReadObject()
     val ow = new ObjectWritable()
-    ow.setConf(new JobConf())
+    ow.setConf(new Configuration())
     ow.readFields(in)
     t = ow.get().asInstanceOf[T]
   }


### PR DESCRIPTION
JobConf's constructor apparently loads default config files in some versions of Hadoop (e.g. https://github.com/apache/hadoop-common/blob/release-1.2.1/src/mapred/org/apache/hadoop/mapred/JobConf.java#L343 calls checkAndWarnDeprecation(), which calls get(), which it needs to check config files to see if deprecated configs are used.) This means that deserializing a SerializableWritable instances rereads these files every time. As far as I can tell, the Configuration passed to ObjectWritable is only used for its embedded ClassLoader, so besides this deprecation check, there would be no reason to load any config files otherwise. Fortunately, there seems to be no similar checks in hadoop.conf.Configuration, and that's actually the type expected by ObjectWritable anyways.
