### PR TITLE
Implementing SPARK-865: Add the equivalent of ADD_JARS to PySpark

### DIFF
--- a/python/pyspark/shell.py
+++ b/python/pyspark/shell.py
@@ -7,9 +7,14 @@ import os
 import pyspark
 from pyspark.context import SparkContext
 
+# this is the equivalent of ADD_JARS
+add_files = os.environ.get("ADD_FILES").split(',') if os.environ.get("ADD_FILES") != None else None
 
-sc = SparkContext(os.environ.get("MASTER", "local"), "PySparkShell")
+sc = SparkContext(os.environ.get("MASTER", "local"), "PySparkShell", pyFiles=add_files)
 print "Spark context avaiable as sc."
+
+if add_files != None:
+    print "Adding files: [%s]" % ", ".join(add_files)
 
 # The ./pyspark script stores the old PYTHONSTARTUP value in OLD_PYTHONSTARTUP,
 # which allows us to execute the user's PYTHONSTARTUP file:


### PR DESCRIPTION
Now ADD_FILES uses a comma as file name separator.
