### PR TITLE
should call reviveOffer in fine-grained mesos mode after tasks successfully finished 

### DIFF
--- a/core/src/main/scala/spark/scheduler/mesos/MesosSchedulerBackend.scala
+++ b/core/src/main/scala/spark/scheduler/mesos/MesosSchedulerBackend.scala
@@ -286,6 +286,9 @@ private[spark] class MesosSchedulerBackend(
         }
       }
       scheduler.statusUpdate(tid, state, status.getData.asReadOnlyByteBuffer)
+      if (isFinished(status.getState)) {
+        d.reviveOffers()
+      }
     } finally {
       restoreClassLoader(oldClassLoader)
     }


### PR DESCRIPTION
[Spark-872]I think we should call reviveOffer in statusUpdate function to request resource, In scheduler.statusUpdate function, it calls reviveOffer only for TASK_LOST and TASK_FAILED, so it need deal with TASK_FINISHED scenario, this improvement will enhance performance significantly. 
