### PR TITLE
Fix PySpark unit tests on Python 2.6

### DIFF
--- a/python/run-tests
+++ b/python/run-tests
@@ -26,20 +26,18 @@ cd "$FWDIR/python"
 
 FAILED=0
 
-$FWDIR/pyspark pyspark/rdd.py
-FAILED=$(($?||$FAILED))
+rm -f unit-tests.log
 
-$FWDIR/pyspark pyspark/context.py
-FAILED=$(($?||$FAILED))
+function run_test() {
+    $FWDIR/pyspark $1 2>&1 | tee -a unit-tests.log
+    FAILED=$((PIPESTATUS[0]||$FAILED))
+}
 
-$FWDIR/pyspark -m doctest pyspark/broadcast.py
-FAILED=$(($?||$FAILED))
-
-$FWDIR/pyspark -m doctest pyspark/accumulators.py
-FAILED=$(($?||$FAILED))
-
-$FWDIR/pyspark -m unittest pyspark.tests
-FAILED=$(($?||$FAILED))
+run_test "pyspark/rdd.py"
+run_test "pyspark/context.py"
+run_test "-m doctest pyspark/broadcast.py"
+run_test "-m doctest pyspark/accumulators.py"
+run_test "pyspark/tests.py"
 
 if [[ $FAILED != 0 ]]; then
     echo -en "\033[31m"  # Red


### PR DESCRIPTION
This commit allows PySpark's unit tests to run on Python 2.6.  A number of Linux distros (including CentOS 6.4, which powers the AMP Lab's Jenkins servers) still use Python 2.6 by default.

I also added logging to the `run-tests` script to redirect the test output into a file.

I updated the Jenkins pull request builder to run these tests, so you should see PySpark output at the end of the test log.
