### PR TITLE
Remove -optimize from compiler flags

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -387,7 +387,7 @@
             <useZincServer>true</useZincServer>
             <args>
               <arg>-unchecked</arg>
-              <arg>-optimise</arg>
+              <arg>-deprecation</arg>
             </args>
             <jvmArgs>
               <jvmArg>-Xms64m</jvmArg>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -67,7 +67,7 @@ object SparkBuild extends Build {
     organization := "org.spark-project",
     version := "0.8.0-SNAPSHOT",
     scalaVersion := "2.9.3",
-    scalacOptions := Seq("-unchecked", "-optimize", "-deprecation"),
+    scalacOptions := Seq("-unchecked", "-deprecation"),
     unmanagedJars in Compile <<= baseDirectory map { base => (base / "lib" ** "*.jar").classpath },
     retrieveManaged := true,
     retrievePattern := "[type]s/[artifact](-[revision])(-[classifier]).[ext]",


### PR DESCRIPTION
According to several reports (e.g. http://stackoverflow.com/questions/6704233/what-does-the-optimise-scala-compiler-flag-do), this flag doesn't do a lot in practice, and indeed on our own performance benchmarks (http://github.com/amplab/spark-perf) it makes no difference. Removing it makes the build about 50% faster.
