### PR TITLE
Removed meaningless types

### DIFF
--- a/core/src/main/scala/spark/util/MutablePair.scala
+++ b/core/src/main/scala/spark/util/MutablePair.scala
@@ -32,5 +32,5 @@ case class MutablePair[@specialized(Int, Long, Double, Char, Boolean/*, AnyRef*/
 {
   override def toString = "(" + _1 + "," + _2 + ")"
 
-  override def canEqual(that: Any): Boolean = that.isInstanceOf[MutablePair[T1, T2]]
+  override def canEqual(that: Any): Boolean = that.isInstanceOf[MutablePair[_,_]]
 }


### PR DESCRIPTION
This PR doesn't change the functionality of the code, but it does remove the misleading implication that a `MutablePair[T1,T2]` can only be equal to a `MutablePair[T3,T4]` if `T1` is the same as `T3` and `T2` is the same as `T4`.  Because of type erasure, there is no such constraint on the types.

If we actually want to disallow equality for MutablePairs of different types, then this is one way to accomplish that:

``` scala
override def canEqual(that: Any): Boolean = that match {
  case m: MutablePair[_,_] => this.getClass.isAssignableFrom(m.getClass)
  case _ => false
}
```

Note that this results in `MutablePair(28, 42) != MutablePair(28L, '*')` and other such comparisons that would currently be `true`, and that we may like to keep that way.
