### PR TITLE
Remove quotes from CLASSPATH in the run script

### DIFF
--- a/run
+++ b/run
@@ -165,7 +165,7 @@ else
   EXTRA_ARGS="$JAVA_OPTS"
 fi
 
-command="$RUNNER -cp \"$CLASSPATH\" $EXTRA_ARGS $@"
+command="$RUNNER -cp $CLASSPATH $EXTRA_ARGS $@"
 if [ "$SPARK_PRINT_LAUNCH_COMMAND" == "1" ]; then
   echo "Spark Command: $command"
   echo "========================================"


### PR DESCRIPTION
The quotes introduced in b4905c383bf24143966d8b2d0ae69ef9ee7c3b0e
break spark-shell and probably other scripts that rely on the
'run' script. This patch removes them. Tested on a couple
Linux machines.
