### PR TITLE
Re-add removed dependency to fix build under Hadoop 0.23.9

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -172,6 +172,7 @@ object SparkBuild extends Build {
       "log4j" % "log4j" % "1.2.17",
       "org.slf4j" % "slf4j-api" % slf4jVersion,
       "org.slf4j" % "slf4j-log4j12" % slf4jVersion,
+      "commons-daemon" % "commons-daemon" % "1.0.10",  // workaround for bug HADOOP-9407
       "com.ning" % "compress-lzf" % "0.8.4",
       "org.xerial.snappy" % "snappy-java" % "1.0.5",
       "org.ow2.asm" % "asm" % "4.0",


### PR DESCRIPTION
This kludge, removed in ff6f1b0500a9a75b61c225f3dc80d4026e98bcd5, is actually needed to convince SBT into successfully building with Hadoop 0.23.9.

The root cause is some differences in error handling between Ivy2 and Maven when parsing internally-inconsistent POM files such as the one for commons-daemon.
