### PR TITLE
Ensure that scripts correctly follow symbolic links to determine the framework directory

### DIFF
--- a/pyspark
+++ b/pyspark
@@ -18,7 +18,7 @@
 #
 
 # Figure out where the Scala framework is installed
-FWDIR="$(cd `dirname $0`; pwd)"
+FWDIR=$(python -c "import os,sys; print os.path.dirname(os.path.realpath(\"$0\"))")
 
 # Export this as SPARK_HOME
 export SPARK_HOME="$FWDIR"

--- a/run
+++ b/run
@@ -20,7 +20,7 @@
 SCALA_VERSION=2.9.3
 
 # Figure out where the Scala framework is installed
-FWDIR="$(cd `dirname $0`; pwd)"
+FWDIR=$(python -c "import os,sys; print os.path.dirname(os.path.realpath(\"$0\"))")
 
 # Export this as SPARK_HOME
 export SPARK_HOME="$FWDIR"

--- a/spark-executor
+++ b/spark-executor
@@ -17,6 +17,6 @@
 # limitations under the License.
 #
 
-FWDIR="`dirname $0`"
+FWDIR=$(python -c "import os,sys; print os.path.dirname(os.path.realpath(\"$0\"))")
 echo "Running spark-executor with framework dir = $FWDIR"
 exec $FWDIR/run spark.executor.MesosExecutorBackend

--- a/spark-shell
+++ b/spark-shell
@@ -28,7 +28,7 @@
 # Enter posix mode for bash
 set -o posix
 
-FWDIR="`dirname $0`"
+FWDIR=$(python -c "import os,sys; print os.path.dirname(os.path.realpath(\"$0\"))")
 
 for o in "$@"; do
   if [ "$1" = "-c" -o "$1" = "--cores" ]; then


### PR DESCRIPTION
Often it may be desirable for packaged versions to create symbolic links to the executor scripts. As they currently stand, the scripts will mis-identify the framework directory using `dirname` to be the directory in which the symlink resides.

The pull request uses a python one-liner as `readlink`'s behaviour can be platform dependent.
