### PR TITLE
Hot fix for command runner

### DIFF
--- a/run
+++ b/run
@@ -172,4 +172,4 @@ if [ "$SPARK_PRINT_LAUNCH_COMMAND" == "1" ]; then
   echo
 fi
 
-exec $command
+exec "$RUNNER" -cp "$CLASSPATH" "$@"

--- a/run
+++ b/run
@@ -172,4 +172,4 @@ if [ "$SPARK_PRINT_LAUNCH_COMMAND" == "1" ]; then
   echo
 fi
 
-exec "$RUNNER" -cp "$CLASSPATH" "$@"
+exec "$RUNNER" -cp "$CLASSPATH" $EXTRA_ARGS "$@"


### PR DESCRIPTION
This is a hotfix for the quote handling issue in `run`. This just reverts it to how it worked before.
