### PR TITLE
Fix removed block zero size log reporting

### DIFF
--- a/core/src/main/scala/spark/storage/BlockManagerMasterActor.scala
+++ b/core/src/main/scala/spark/storage/BlockManagerMasterActor.scala
@@ -372,12 +372,12 @@ object BlockManagerMasterActor {
         if (blockStatus.storageLevel.useMemory) {
           _remainingMem += blockStatus.memSize
           logInfo("Removed %s on %s in memory (size: %s, free: %s)".format(
-            blockId, blockManagerId.hostPort, Utils.bytesToString(memSize),
+            blockId, blockManagerId.hostPort, Utils.bytesToString(blockStatus.memSize),
             Utils.bytesToString(_remainingMem)))
         }
         if (blockStatus.storageLevel.useDisk) {
           logInfo("Removed %s on %s on disk (size: %s)".format(
-            blockId, blockManagerId.hostPort, Utils.bytesToString(diskSize)))
+            blockId, blockManagerId.hostPort, Utils.bytesToString(blockStatus.diskSize)))
         }
       }
     }


### PR DESCRIPTION
`memSize` and `diskSize` of **removed** block will always report as 0.0 B, like this:

```
INFO BlockManagerMasterActor$BlockManagerInfo:Removed input-2-1377741792200 on xxx in memory (size: 0.0 B, free: 2.8 GB)
```

Cause input parameter `memSize` and `diskSize` calculated in BlockManager will always be zero. It would be better to display the actual size of this block when reporting this log.

Thanks
Jerry
