### PR TITLE
PySpark: replacing class manifest by class tag for Scala 2.10.2 in rdd.py

### DIFF
--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -731,13 +731,13 @@ class PipelinedRDD(RDD):
             [x._jbroadcast for x in self.ctx._pickled_broadcast_vars],
             self.ctx._gateway._gateway_client)
         self.ctx._pickled_broadcast_vars.clear()
-        class_manifest = self._prev_jrdd.classManifest()
+        class_tag = self._prev_jrdd.classTag()
         env = copy.copy(self.ctx.environment)
         env['PYTHONPATH'] = os.environ.get("PYTHONPATH", "")
         env = MapConverter().convert(env, self.ctx._gateway._gateway_client)
         python_rdd = self.ctx._jvm.PythonRDD(self._prev_jrdd.rdd(),
             pipe_command, env, self.preservesPartitioning, self.ctx.pythonExec,
-            broadcast_vars, self.ctx._javaAccumulator, class_manifest)
+            broadcast_vars, self.ctx._javaAccumulator, class_tag)
         self._jrdd_val = python_rdd.asJavaRDD()
         return self._jrdd_val
 


### PR DESCRIPTION
See https://groups.google.com/forum/#!topic/spark-users/d4kHEsSKPyc
