### PR TITLE
Missing metrics-ganglia dependency in core/pom.xml

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -147,6 +147,10 @@
       <artifactId>metrics-json</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.codahale.metrics</groupId>
+      <artifactId>metrics-ganglia</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derby</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
Previously defined dependency has to actually be used in core.
