### PR TITLE
Get rid of / improve ugly NPE when Utils.deleteRecursively() fails

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -459,7 +459,9 @@ private[spark] object Utils extends Logging {
 
   private def listFilesSafely(file: File): Seq[File] = {
     val files = file.listFiles()
-    if (files == null) throw new IOException("Failed to list files for dir: " + file)
+    if (files == null) {
+      throw new IOException("Failed to list files for dir: " + file)
+    }
     files
   }
 

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -457,12 +457,18 @@ private[spark] object Utils extends Logging {
   def newDaemonFixedThreadPool(nThreads: Int): ThreadPoolExecutor =
     Executors.newFixedThreadPool(nThreads, daemonThreadFactory).asInstanceOf[ThreadPoolExecutor]
 
+  private def listFilesSafely(file: File): Seq[File] = {
+    val files = file.listFiles()
+    if (files == null) throw new IOException("Failed to list files for dir: " + file)
+    files
+  }
+
   /**
    * Delete a file or directory and its contents recursively.
    */
   def deleteRecursively(file: File) {
     if (file.isDirectory) {
-      for (child <- file.listFiles()) {
+      for (child <- listFilesSafely(file)) {
         deleteRecursively(child)
       }
     }


### PR DESCRIPTION
listFiles() could return null if the I/O fails, and this currently results in an ugly NPE which is hard to diagnose.
