### PR TITLE
Add explicit jets3t dependency, which is excluded in hadoop-client

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -37,6 +37,11 @@
       <artifactId>hadoop-client</artifactId>
     </dependency>
     <dependency>
+      <groupId>net.java.dev.jets3t</groupId>
+      <artifactId>jets3t</artifactId>
+      <version>0.7.1</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -374,6 +374,11 @@
         </exclusions>
       </dependency>
       <dependency>
+        <groupId>net.java.dev.jets3t</groupId>
+        <artifactId>jets3t</artifactId>
+        <version>0.7.1</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-yarn-api</artifactId>
         <version>${hadoop.version}</version>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -208,6 +208,7 @@ object SparkBuild extends Build {
       "io.netty" % "netty-all" % "4.0.0.Beta2",
       "org.apache.derby" % "derby" % "10.4.2.0" % "test",
       "org.apache.hadoop" % "hadoop-client" % hadoopVersion excludeAll(excludeJackson, excludeNetty, excludeAsm),
+      "net.java.dev.jets3t" % "jets3t" % "0.7.1",
       "org.apache.avro" % "avro" % "1.7.4",
       "org.apache.avro" % "avro-ipc" % "1.7.4" excludeAll(excludeNetty),
       "com.codahale.metrics" % "metrics-core" % "3.0.0",


### PR DESCRIPTION
Version 0.7.1 is required for Hadoop 1.0.4 -- newer versions won't work. For newer Hadoops, if Hadoop starts using a new jets3t, users can manually depend on it.
