### PR TITLE
Fix HDFS access bug with assembly build.

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -106,6 +106,12 @@
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                  <resource>META-INF/services/org.apache.hadoop.fs.FileSystem</resource>
+                </transformer>
+              </transformers>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                   <resource>reference.conf</resource>
                 </transformer>
               </transformers>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -303,6 +303,7 @@ object SparkBuild extends Build {
     mergeStrategy in assembly := {
       case m if m.toLowerCase.endsWith("manifest.mf") => MergeStrategy.discard
       case m if m.toLowerCase.matches("meta-inf.*\\.sf$") => MergeStrategy.discard
+      case "META-INF/services/org.apache.hadoop.fs.FileSystem" => MergeStrategy.concat
       case "reference.conf" => MergeStrategy.concat
       case _ => MergeStrategy.first
     }


### PR DESCRIPTION
Due to this change in HDFS:
https://issues.apache.org/jira/browse/HADOOP-7549

there is a bug when using the new assembly builds with newer versions of Hadoop. The symptom is 
that any HDFS access results in an exception saying "No filesystem for scheme 'hdfs'". This adds a
merge strategy in the assembly build which fixes the problem by ensuring that if two jars expose
the manifest (in this case, hadoop-common and hadoop-hdfs), the assembly plugin concatenates them.
