### PR TITLE
Changed localProperties to use ThreadLocal (not DynamicVariable).

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -27,7 +27,6 @@ import scala.collection.generic.Growable
 import scala.collection.JavaConversions._
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.mutable.HashMap
-import scala.util.DynamicVariable
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
@@ -257,20 +256,20 @@ class SparkContext(
   private[spark] var checkpointDir: Option[String] = None
 
   // Thread Local variable that can be used by users to pass information down the stack
-  private val localProperties = new DynamicVariable[Properties](null)
+  private val localProperties = new ThreadLocal[Properties]
 
   def initLocalProperties() {
-    localProperties.value = new Properties()
+    localProperties.set(new Properties())
   }
 
   def setLocalProperty(key: String, value: String) {
-    if (localProperties.value == null) {
-      localProperties.value = new Properties()
+    if (localProperties.get() == null) {
+      localProperties.set(new Properties())
     }
     if (value == null) {
-      localProperties.value.remove(key)
+      localProperties.get.remove(key)
     } else {
-      localProperties.value.setProperty(key, value)
+      localProperties.get.setProperty(key, value)
     }
   }
 
@@ -724,7 +723,7 @@ class SparkContext(
     logInfo("Starting job: " + callSite)
     val start = System.nanoTime
     val result = dagScheduler.runJob(rdd, func, partitions, callSite, allowLocal, resultHandler,
-      localProperties.value)
+      localProperties.get)
     logInfo("Job finished: " + callSite + ", took " + (System.nanoTime - start) / 1e9 + " s")
     rdd.doCheckpoint()
     result
@@ -807,7 +806,8 @@ class SparkContext(
     val callSite = Utils.formatSparkCallSite
     logInfo("Starting job: " + callSite)
     val start = System.nanoTime
-    val result = dagScheduler.runApproximateJob(rdd, func, evaluator, callSite, timeout, localProperties.value)
+    val result = dagScheduler.runApproximateJob(rdd, func, evaluator, callSite, timeout,
+      localProperties.get)
     logInfo("Job finished: " + callSite + ", took " + (System.nanoTime - start) / 1e9 + " s")
     result
   }


### PR DESCRIPTION
The fact that DynamicVariable uses an InheritableThreadLocal
can cause problems where the the localProperties variable is
shared across threads; Spark should use a TheadLocal instead.  The
bug only occurs when someone runs a Spark job in a thread,
and then runs many concurrent Spark jobs in child threads.
Here's how the problem can occur:

sc = new SparkContext(...)
sc.setJobDescription("Foo")

(1 to 2).map { i ->
  new Thread() {
    override def run() {
        sc.setJobDescription("Job " + i)
        Thread.sleep(100)
        sc.makeRdd(.....)
    }
}

In this code, both jobs will end up with the same description.

On the first call to setJobDescription(),  SparkContext.setLocalProperty() will find that localProperties (a Dynamic variable) is null -- so it will initialize it, and then set the job description property to foo.

When each of the two new threads is created, the value of localProperties is inherited from the value in the parent thread, which is an InheritableThreadLocal.  The way that the InheritableThreadLocal childValue() function works is that it just returns a reference to the parent value (http://docs.oracle.com/javase/6/docs/api/java/lang/InheritableThreadLocal.html#childValue(T)) -- so now the localProperties variable in both child threads refers to the same underlying Properties.
