### PR TITLE
Use different Hadoop version for YARN artifacts.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
     <slf4j.version>1.7.2</slf4j.version>
     <log4j.version>1.2.17</log4j.version>
     <hadoop.version>1.0.4</hadoop.version>
+    <yarn.version>0.23.7</yarn.version>
     <hbase.version>0.94.6</hbase.version>
 
     <PermGen>64m</PermGen>
@@ -382,7 +383,7 @@
       <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-yarn-api</artifactId>
-        <version>${hadoop.version}</version>
+        <version>${yarn.version}</version>
         <exclusions>
           <exclusion>
             <groupId>asm</groupId>
@@ -413,7 +414,7 @@
       <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-yarn-common</artifactId>
-        <version>${hadoop.version}</version>
+        <version>${yarn.version}</version>
         <exclusions>
           <exclusion>
             <groupId>asm</groupId>
@@ -444,7 +445,7 @@
       <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-yarn-client</artifactId>
-        <version>${hadoop.version}</version>
+        <version>${yarn.version}</version>
         <exclusions>
           <exclusion>
             <groupId>asm</groupId>
@@ -700,8 +701,8 @@
       <properties>
         <hadoop.major.version>2</hadoop.major.version>
         <!-- 0.23.* is same as 2.0.* - except hardened to run production jobs -->
-        <!-- <hadoop.version>0.23.7</hadoop.version> -->
-        <hadoop.version>2.0.5-alpha</hadoop.version>
+        <hadoop.version>0.23.7</hadoop.version>
+        <!--<hadoop.version>2.0.5-alpha</hadoop.version> -->
       </properties>
 
       <modules>

--- a/yarn/pom.xml
+++ b/yarn/pom.xml
@@ -49,6 +49,11 @@
       <artifactId>hadoop-yarn-client</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-client</artifactId>
+      <version>${yarn.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
     </dependency>


### PR DESCRIPTION
This uses a seperate Hadoop version for YARN artifact. This means when people link against
spark-yarn, things will resolve correctly.
