### PR TITLE
Fix typo in Maven build docs

### DIFF
--- a/docs/building-with-maven.md
+++ b/docs/building-with-maven.md
@@ -40,10 +40,10 @@ For Apache Hadoop versions 1.x, Cloudera CDH MRv1, and other Hadoop versions wit
 For Apache Hadoop 2.x, 0.23.x, Cloudera CDH MRv2, and other Hadoop versions with YARN, you should enable the "hadoop2-yarn" profile and set the "yarn.version" property:
 
     # Apache Hadoop 2.0.5-alpha
-    $ mvn -Phadoop2-yarn -Dhadoop.version=2.0.5-alpha -Pyarn.version=2.0.5-alpha -DskipTests clean package
+    $ mvn -Phadoop2-yarn -Dhadoop.version=2.0.5-alpha -Dyarn.version=2.0.5-alpha -DskipTests clean package
 
     # Cloudera CDH 4.2.0 with MapReduce v2
-    $ mvn -Phadoop2-yarn -Dhadoop.version=2.0.0-cdh4.2.0 -Pyarn.version=2.0.0-chd4.2.0 -DskipTests clean package
+    $ mvn -Phadoop2-yarn -Dhadoop.version=2.0.0-cdh4.2.0 -Dyarn.version=2.0.0-chd4.2.0 -DskipTests clean package
 
 
 ## Spark Tests in Maven ##


### PR DESCRIPTION
Fixes a typo introduced in #931, where "-P" was written instead of "-D"
