### PR TITLE
Fix PR926 local properties issues in Spark Streaming like scenarios

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -275,7 +275,8 @@ class SparkContext(
     }
   }
 
-  def getLocalProperty(key: String): String = Option(localProperties.get).map(_.getProperty(key)).getOrElse(null)
+  def getLocalProperty(key: String): String =
+    Option(localProperties.get).map(_.getProperty(key)).getOrElse(null)
 
   /** Set a human readable description of the current job. */
   def setJobDescription(value: String) {

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -256,7 +256,9 @@ class SparkContext(
   private[spark] var checkpointDir: Option[String] = None
 
   // Thread Local variable that can be used by users to pass information down the stack
-  private val localProperties = new ThreadLocal[Properties]
+  private val localProperties = new InheritableThreadLocal[Properties] {
+    override protected def childValue(parent: Properties): Properties = new Properties(parent)
+  }
 
   def initLocalProperties() {
     localProperties.set(new Properties())
@@ -272,6 +274,8 @@ class SparkContext(
       localProperties.get.setProperty(key, value)
     }
   }
+
+  def getLocalProperty(key: String): String = Option(localProperties.get).map(_.getProperty(key)).getOrElse(null)
 
   /** Set a human readable description of the current job. */
   def setJobDescription(value: String) {


### PR DESCRIPTION
[PR926](https://github.com/mesos/spark/pull/926) changes local properties from `DynamicVariable` to `ThreadLocal`,   which cannot pass properties set in parent thread to child thread. Scenarios like Spark Streaming which separate `runJob()` function in child thread will always get `null` properties and pass to DAGScheduler. So thread local properties should be inheritable, also should be isolated in different threads.
