### PR TITLE
Fixed non termination of Executor backend, when sc.stop is not called and system.exit instead.

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
@@ -165,7 +165,7 @@ private[spark] class Worker(
           logInfo("Asked to kill unknown executor " + fullId)
       }
 
-    case _: Terminated | DisassociatedEvent | AssociationErrorEvent =>
+    case DisassociatedEvent(_, _, _) =>
       masterDisconnected()
 
     case RequestWorkerState => {

--- a/core/src/main/scala/org/apache/spark/executor/StandaloneExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/StandaloneExecutorBackend.scala
@@ -81,7 +81,7 @@ private[spark] class StandaloneExecutorBackend(
         executor.launchTask(this, taskDesc.taskId, taskDesc.serializedTask)
       }
 
-    case _: Terminated | DisassociatedEvent | AssociationErrorEvent =>
+    case DisassociatedEvent(_, _, _) =>
       logError("Driver terminated or disconnected! Shutting down.")
       System.exit(1)
   }


### PR DESCRIPTION
A simple fix suggestion. 
